### PR TITLE
Add podcast and episode search

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -15,6 +15,13 @@ body {
 	user-select: none;
 }
 
+input,
+textarea {
+	-webkit-user-select: text;
+	user-select: text;
+	touch-action: auto;
+}
+
 * {
 	touch-action: pan-x pan-y;
 }

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -5,7 +5,9 @@ declare global {
 		// interface Error {}
 		// interface Locals {}
 		// interface PageData {}
-		// interface PageState {}
+		interface PageState {
+			search?: boolean;
+		}
 		// interface Platform {}
 	}
 }

--- a/src/lib/components/Navbar.svelte
+++ b/src/lib/components/Navbar.svelte
@@ -1,28 +1,75 @@
 <script lang="ts">
-	import { goto, onNavigate } from '$app/navigation';
-	import { ChevronLeft, Settings, SquareArrowOutUpRight } from 'lucide-svelte';
+	import { beforeNavigate, goto, onNavigate } from '$app/navigation';
+	import { ChevronLeft, Search, Settings, SquareArrowOutUpRight } from 'lucide-svelte';
 	import TouchableButton from '$lib/components/utility/TouchableButton.svelte';
+	import SearchInput from '$lib/components/utility/SearchInput.svelte';
 	import { config } from '$lib/config/config';
 	import { getIconComponent } from '$lib/util/getIconComponent';
 	import { writable } from 'svelte/store';
 	import ExternalLinksModal from '$lib/components/modals/ExternalLinksModal.svelte';
-	import { onMount } from 'svelte';
+	import { onMount, tick } from 'svelte';
 	import { t } from '$lib/i18n';
+	import { searchOpen, searchQuery, openSearch, closeSearch } from '$lib/stores/search';
 
 	const showBackButton = writable(false);
 	let externalLinksModal: ExternalLinksModal;
+	let searchButtonEl: HTMLElement | null = null;
+	let wasSearchOpen = false;
+
+	$: searchOpenOnHome = !$showBackButton && $searchOpen;
+
+	$: {
+		if (wasSearchOpen && !$searchOpen) {
+			searchQuery.set('');
+			void restoreSearchButtonFocus();
+		}
+		wasSearchOpen = $searchOpen;
+	}
 
 	onMount(() => {
 		showBackButton.set(window.location.pathname !== '/');
 	});
 
+	beforeNavigate((navigation) => {
+		if (
+			navigation.type !== 'popstate' &&
+			$searchOpen &&
+			navigation.from?.url.pathname === '/' &&
+			navigation.to?.url.pathname !== '/'
+		) {
+			closeSearch({ popHistory: false });
+		}
+	});
+
 	onNavigate((navigation) => {
 		showBackButton.set(navigation.to?.url.pathname !== '/');
 	});
+
+	async function restoreSearchButtonFocus() {
+		await tick();
+		if (searchButtonEl?.isConnected) {
+			searchButtonEl.focus();
+		}
+	}
+
+	function handleSearchKeydown(event: KeyboardEvent) {
+		if (
+			event.key === 'Escape' &&
+			$searchOpen &&
+			!event.defaultPrevented &&
+			!event.isComposing &&
+			!document.querySelector('dialog[open]')
+		) {
+			event.preventDefault();
+			closeSearch();
+		}
+	}
 </script>
 
-<div class="flex justify-between">
-	<div class="flex items-center">
+<svelte:window on:keydown={handleSearchKeydown} />
+
+<div class="flex w-full items-center gap-1 sm:gap-2">
+	<div class="flex shrink-0 items-center {searchOpenOnHome ? 'max-sm:hidden' : ''}">
 		<TouchableButton
 			onClick={() => ($showBackButton ? window.history.back() : goto('/'))}
 			ariaLabel={$t.navbar.goBack}
@@ -33,7 +80,12 @@
 			{#if $showBackButton}
 				<ChevronLeft class="w-[32px]" />
 			{:else}
-				<img src="/favicon.png" alt="Logo" class="h-full w-[32px] rounded-full border border-base-content/30" draggable="false" />
+				<img
+					src="/favicon.png"
+					alt="Logo"
+					class="h-full w-[32px] rounded-full border border-base-content/30"
+					draggable="false"
+				/>
 			{/if}
 		</TouchableButton>
 		<a href="/" class={`text-l z-10 pl-0 font-bold text-base-content sm:text-2xl`}>
@@ -41,9 +93,42 @@
 		</a>
 	</div>
 
-	<!-- Social Links -->
-	<div class="flex items-center">
-		{#each config.website.links as link}
+	<div class="ml-auto flex min-w-0 flex-1 items-center justify-end sm:flex-none">
+		{#if searchOpenOnHome}
+			<div
+				role="search"
+				aria-label={$t.home.searchLabel}
+				class="flex min-w-0 flex-1 items-center gap-1 sm:flex-none sm:w-72 md:w-80 lg:w-96"
+			>
+				<TouchableButton
+					onClick={closeSearch}
+					ariaLabel={$t.navbar.closeSearch}
+					circle={false}
+					buttonClassName="px-1"
+					size="sm"
+				>
+					<ChevronLeft class="w-[32px]" />
+				</TouchableButton>
+				<SearchInput
+					bind:value={$searchQuery}
+					placeholder={$t.home.searchPlaceholder}
+					ariaLabel={$t.home.searchLabel}
+					clearLabel={$t.home.searchClear}
+				/>
+			</div>
+		{:else if !$showBackButton}
+			<TouchableButton
+				bind:el={searchButtonEl}
+				onClick={openSearch}
+				ariaLabel={$t.navbar.search}
+				circle={false}
+				size="sm"
+			>
+				<Search class="h-5 w-5 sm:h-6 sm:w-6" />
+			</TouchableButton>
+		{/if}
+
+		{#each config.website.links as link (link.url)}
 			<TouchableButton
 				onClick={() => window.open(link.url, '_blank', 'noopener,noreferrer')}
 				ariaLabel={link.iconLabel}

--- a/src/lib/components/Navbar.svelte
+++ b/src/lib/components/Navbar.svelte
@@ -15,8 +15,35 @@
 	let externalLinksModal: ExternalLinksModal;
 	let searchButtonEl: HTMLElement | null = null;
 	let wasSearchOpen = false;
+	let leftGroupEl: HTMLDivElement | null = null;
+	let logoEl: HTMLElement | null = null;
+	let titleMeasureEl: HTMLSpanElement | null = null;
+	let titleFits = false;
+	let scrolled = false;
+	let isMobile = false;
+
+	const MOBILE_MQ = '(max-width: 639px)';
+	const SCROLL_COMPACT_PX = 24;
+	const SCROLL_EXPAND_PX = 8;
+
+	function measureTitleFit() {
+		if (!leftGroupEl || !titleMeasureEl) return;
+		if (leftGroupEl.clientWidth === 0) return;
+		const available = leftGroupEl.clientWidth - (logoEl?.offsetWidth ?? 0);
+		titleFits = titleMeasureEl.offsetWidth <= available;
+	}
+
+	function syncScrollerState(scroller: HTMLElement) {
+		const top = scroller.scrollTop;
+		if (top > SCROLL_COMPACT_PX) scrolled = true;
+		else if (top < SCROLL_EXPAND_PX) scrolled = false;
+	}
 
 	$: searchOpenOnHome = !$showBackButton && $searchOpen;
+	$: compactSearch = isMobile && !$showBackButton && scrolled;
+	$: showSearchField = searchOpenOnHome || compactSearch;
+	$: hideChrome = isMobile && showSearchField;
+	$: searchOpenOnHome, $showBackButton, void tick().then(measureTitleFit);
 
 	$: {
 		if (wasSearchOpen && !$searchOpen) {
@@ -28,6 +55,32 @@
 
 	onMount(() => {
 		showBackButton.set(window.location.pathname !== '/');
+		const resizeObserver = new ResizeObserver(() => measureTitleFit());
+		if (leftGroupEl) resizeObserver.observe(leftGroupEl);
+		if (titleMeasureEl) resizeObserver.observe(titleMeasureEl);
+		window.addEventListener('resize', measureTitleFit);
+		void tick().then(measureTitleFit);
+
+		const mediaQuery = window.matchMedia(MOBILE_MQ);
+		const syncMobile = () => {
+			isMobile = mediaQuery.matches;
+		};
+		syncMobile();
+		mediaQuery.addEventListener('change', syncMobile);
+
+		const scroller = document.querySelector<HTMLElement>('[data-main-scroller]');
+		const onScroll = () => {
+			if (scroller) syncScrollerState(scroller);
+		};
+		scroller?.addEventListener('scroll', onScroll, { passive: true });
+		if (scroller) syncScrollerState(scroller);
+
+		return () => {
+			resizeObserver.disconnect();
+			window.removeEventListener('resize', measureTitleFit);
+			mediaQuery.removeEventListener('change', syncMobile);
+			scroller?.removeEventListener('scroll', onScroll);
+		};
 	});
 
 	beforeNavigate((navigation) => {
@@ -69,12 +122,19 @@
 <svelte:window on:keydown={handleSearchKeydown} />
 
 <div class="flex w-full items-center gap-1 sm:gap-2">
-	<div class="flex shrink-0 items-center {searchOpenOnHome ? 'max-sm:hidden' : ''}">
+	<div
+		bind:this={leftGroupEl}
+		class="relative flex min-w-0 flex-1 items-center overflow-hidden {searchOpenOnHome
+			? 'max-sm:hidden'
+			: ''} {compactSearch ? 'hidden' : ''}"
+	>
 		<TouchableButton
+			bind:el={logoEl}
 			onClick={() => ($showBackButton ? window.history.back() : goto('/'))}
 			ariaLabel={$t.navbar.goBack}
 			circle={false}
 			buttonClassName="px-1"
+			className="shrink-0"
 			size="sm"
 		>
 			{#if $showBackButton}
@@ -88,32 +148,51 @@
 				/>
 			{/if}
 		</TouchableButton>
-		<a href="/" class={`text-l z-10 pl-0 font-bold text-base-content sm:text-2xl`}>
+		<span
+			bind:this={titleMeasureEl}
+			class="pointer-events-none invisible absolute whitespace-nowrap text-base font-bold sm:text-xl"
+			aria-hidden="true"
+		>
 			{config.website.title}
-		</a>
+		</span>
+		{#if titleFits}
+			<a href="/" class="whitespace-nowrap pl-0 text-base font-bold text-base-content sm:text-xl">
+				{config.website.title}
+			</a>
+		{/if}
 	</div>
 
-	<div class="ml-auto flex min-w-0 flex-1 items-center justify-end sm:flex-none">
-		{#if searchOpenOnHome}
+	<div
+		class="ml-auto flex items-center justify-end {showSearchField
+			? 'min-w-0 flex-1'
+			: 'shrink-0'}"
+	>
+		{#if showSearchField}
 			<div
 				role="search"
 				aria-label={$t.home.searchLabel}
-				class="flex min-w-0 flex-1 items-center gap-1 sm:flex-none sm:w-72 md:w-80 lg:w-96"
+				class="flex min-w-0 flex-1 items-center gap-1 {searchOpenOnHome
+					? 'sm:flex-none sm:w-72 md:w-80 lg:w-96'
+					: ''}"
 			>
-				<TouchableButton
-					onClick={closeSearch}
-					ariaLabel={$t.navbar.closeSearch}
-					circle={false}
-					buttonClassName="px-1"
-					size="sm"
-				>
-					<ChevronLeft class="w-[32px]" />
-				</TouchableButton>
+				{#if searchOpenOnHome}
+					<TouchableButton
+						onClick={closeSearch}
+						ariaLabel={$t.navbar.closeSearch}
+						circle={false}
+						buttonClassName="px-1"
+						size="sm"
+					>
+						<ChevronLeft class="w-[32px]" />
+					</TouchableButton>
+				{/if}
 				<SearchInput
 					bind:value={$searchQuery}
 					placeholder={$t.home.searchPlaceholder}
 					ariaLabel={$t.home.searchLabel}
 					clearLabel={$t.home.searchClear}
+					focusOnMount={searchOpenOnHome}
+					onFocus={openSearch}
 				/>
 			</div>
 		{:else if !$showBackButton}
@@ -128,34 +207,36 @@
 			</TouchableButton>
 		{/if}
 
-		{#each config.website.links as link (link.url)}
+		{#if !hideChrome}
+			{#each config.website.links as link (link.url)}
+				<TouchableButton
+					onClick={() => window.open(link.url, '_blank', 'noopener,noreferrer')}
+					ariaLabel={link.iconLabel}
+					circle={false}
+					size="sm"
+				>
+					<svelte:component this={getIconComponent(link.iconLabel)} class="h-5 w-5 sm:h-6 sm:w-6" />
+				</TouchableButton>
+			{/each}
+
 			<TouchableButton
-				onClick={() => window.open(link.url, '_blank', 'noopener,noreferrer')}
-				ariaLabel={link.iconLabel}
+				onClick={() => externalLinksModal.open()}
+				ariaLabel={$t.navbar.otherLinks}
 				circle={false}
 				size="sm"
 			>
-				<svelte:component this={getIconComponent(link.iconLabel)} class="h-5 w-5 sm:h-6 sm:w-6" />
+				<SquareArrowOutUpRight class="h-5 w-5 sm:h-6 sm:w-6" />
 			</TouchableButton>
-		{/each}
 
-		<TouchableButton
-			onClick={() => externalLinksModal.open()}
-			ariaLabel={$t.navbar.otherLinks}
-			circle={false}
-			size="sm"
-		>
-			<SquareArrowOutUpRight class="h-5 w-5 sm:h-6 sm:w-6" />
-		</TouchableButton>
-
-		<TouchableButton
-			onClick={() => goto('/settings')}
-			ariaLabel={$t.settings.title}
-			circle={false}
-			size="sm"
-		>
-			<Settings class="h-5 w-5 sm:h-6 sm:w-6" />
-		</TouchableButton>
+			<TouchableButton
+				onClick={() => goto('/settings')}
+				ariaLabel={$t.settings.title}
+				circle={false}
+				size="sm"
+			>
+				<Settings class="h-5 w-5 sm:h-6 sm:w-6" />
+			</TouchableButton>
+		{/if}
 	</div>
 </div>
 

--- a/src/lib/components/Navbar.svelte
+++ b/src/lib/components/Navbar.svelte
@@ -117,6 +117,17 @@
 			closeSearch();
 		}
 	}
+
+	function handleDesktopSearchBlur() {
+		if (isMobile) return;
+		if ($searchQuery.trim()) return;
+		closeSearch();
+	}
+
+	function handleDesktopSearchClear() {
+		if (isMobile) return;
+		closeSearch();
+	}
 </script>
 
 <svelte:window on:keydown={handleSearchKeydown} />
@@ -181,6 +192,7 @@
 						ariaLabel={$t.navbar.closeSearch}
 						circle={false}
 						buttonClassName="px-1"
+						className="sm:hidden"
 						size="sm"
 					>
 						<ChevronLeft class="w-[32px]" />
@@ -193,6 +205,8 @@
 					clearLabel={$t.home.searchClear}
 					focusOnMount={searchOpenOnHome}
 					onFocus={openSearch}
+					onBlur={handleDesktopSearchBlur}
+					onClear={handleDesktopSearchClear}
 				/>
 			</div>
 		{:else if !$showBackButton}

--- a/src/lib/components/PodcastCard.svelte
+++ b/src/lib/components/PodcastCard.svelte
@@ -41,19 +41,25 @@
 		return `${baseClasses} ${isActive ? 'bg-base-300 shadow-xl outline outline-2 outline-offset-1 outline-primary' : 'bg-base-100 hover:bg-base-300'}`;
 	}
 
-	function getEpisodeSource(source: Podcast, ids?: string[]): Episode[] {
-		if (!ids || ids.length === 0) return source.items;
+	function getEpisodeSource(
+		source: Podcast,
+		field: MatchField | undefined,
+		ids?: string[]
+	): Episode[] {
+		if (field !== 'episode' || !ids || ids.length === 0) return source.items;
 		const idSet = new Set(ids);
 		return source.items.filter((episode) => idSet.has(episode.id));
 	}
 
-	$: episodeSource = getEpisodeSource(podcast, matchedEpisodeIds);
-	$: sourceKey = `${podcast.id}:${(matchedEpisodeIds ?? []).join('|')}`;
+	$: episodeSource = getEpisodeSource(podcast, matchField, matchedEpisodeIds);
+	$: sourceKey = `${podcast.id}:${matchField ?? ''}:${matchField === 'episode' ? (matchedEpisodeIds ?? []).join('|') : ''}`;
 	$: badgeLabel =
 		matchField === 'title'
 			? $t.home.searchMatchTitle
 			: matchField === 'episode'
-				? formatString($t.home.searchMatchEpisodes, { count: matchedEpisodeIds?.length ?? 0 })
+				? (matchedEpisodeIds?.length ?? 0) === 1
+					? $t.home.searchMatchEpisode
+					: formatString($t.home.searchMatchEpisodes, { count: matchedEpisodeIds?.length ?? 0 })
 				: '';
 
 	function loadMoreEpisodes() {
@@ -115,6 +121,13 @@
 		if (!url) return;
 		await copyTextToClipboard(url);
 		showTooltip(get(t).player.linkCopied, 3000, shareTooltipAnchorEl);
+	}
+
+	let lastPodcastId = podcast.id;
+	$: if (podcast.id !== lastPodcastId) {
+		lastPodcastId = podcast.id;
+		imageLoaded = false;
+		isReversed = false;
 	}
 
 	let lastSourceKey = '';

--- a/src/lib/components/PodcastCard.svelte
+++ b/src/lib/components/PodcastCard.svelte
@@ -9,15 +9,19 @@
 	import { fade } from 'svelte/transition';
 	import PodcastInfoModal from '$lib/components/modals/PodcastInfoModal.svelte';
 	import type { Episode, Podcast } from '$lib/stores/podcast/podcasts';
-	import { t } from '$lib/i18n';
+	import { formatString, t } from '$lib/i18n';
 	import { sharePodcast, copyTextToClipboard } from '$lib/util/share';
 	import { showTooltip } from '$lib/util/tooltip';
 	import { get } from 'svelte/store';
 	import { clampText } from '$lib/util/text';
+	import { splitHighlight, type MatchField } from '$lib/util/search';
 
 	export let podcast: Podcast;
 	export let expanded = false;
 	export let onExpand: (podcastId: string, isExpanded: boolean) => void;
+	export let matchField: MatchField | undefined = undefined;
+	export let matchedEpisodeIds: string[] | undefined = undefined;
+	export let highlightQuery = '';
 
 	let imageLoaded = false;
 
@@ -37,11 +41,26 @@
 		return `${baseClasses} ${isActive ? 'bg-base-300 shadow-xl outline outline-2 outline-offset-1 outline-primary' : 'bg-base-100 hover:bg-base-300'}`;
 	}
 
+	function getEpisodeSource(source: Podcast, ids?: string[]): Episode[] {
+		if (!ids || ids.length === 0) return source.items;
+		const idSet = new Set(ids);
+		return source.items.filter((episode) => idSet.has(episode.id));
+	}
+
+	$: episodeSource = getEpisodeSource(podcast, matchedEpisodeIds);
+	$: sourceKey = `${podcast.id}:${(matchedEpisodeIds ?? []).join('|')}`;
+	$: badgeLabel =
+		matchField === 'title'
+			? $t.home.searchMatchTitle
+			: matchField === 'episode'
+				? formatString($t.home.searchMatchEpisodes, { count: matchedEpisodeIds?.length ?? 0 })
+				: '';
+
 	function loadMoreEpisodes() {
 		const currentLength = visibleEpisodes.length;
 		const nextBatch = isReversed
-			? podcast.items.slice(-(currentLength + BATCH_SIZE), -currentLength).reverse()
-			: podcast.items.slice(currentLength, currentLength + BATCH_SIZE);
+			? episodeSource.slice(-(currentLength + BATCH_SIZE), -currentLength).reverse()
+			: episodeSource.slice(currentLength, currentLength + BATCH_SIZE);
 		if (nextBatch.length > 0) {
 			visibleEpisodes = [...visibleEpisodes, ...nextBatch];
 		}
@@ -60,19 +79,19 @@
 			$playerStore.currentPodcast?.id === podcast.id &&
 			$playerStore.currentEpisode
 		) {
-			const episodeIndex = podcast.items.findIndex(
+			const episodeIndex = episodeSource.findIndex(
 				(e: Episode) => e.id === $playerStore.currentEpisode?.id
 			);
 			if (episodeIndex >= 0) {
-				const indexFromEnd = podcast.items.length - 1 - episodeIndex;
+				const indexFromEnd = episodeSource.length - 1 - episodeIndex;
 				const batchesNeeded =
 					Math.floor((isReversed ? indexFromEnd : episodeIndex) / BATCH_SIZE) + 1;
 				const totalToLoad = batchesNeeded * BATCH_SIZE;
 
 				if (isReversed) {
-					visibleEpisodes = podcast.items.slice(-totalToLoad).reverse();
+					visibleEpisodes = episodeSource.slice(-totalToLoad).reverse();
 				} else {
-					visibleEpisodes = podcast.items.slice(0, totalToLoad);
+					visibleEpisodes = episodeSource.slice(0, totalToLoad);
 				}
 			}
 		}
@@ -83,8 +102,8 @@
 		// Recalculate visible episodes from the correct position
 		const currentCount = visibleEpisodes.length;
 		const episodes = isReversed
-			? podcast.items.slice(-currentCount).reverse()
-			: podcast.items.slice(0, currentCount);
+			? episodeSource.slice(-currentCount).reverse()
+			: episodeSource.slice(0, currentCount);
 		visibleEpisodes = episodes;
 		loadUpToCurrentEpisode();
 		togglePlaylist(podcast.id);
@@ -98,51 +117,66 @@
 		showTooltip(get(t).player.linkCopied, 3000, shareTooltipAnchorEl);
 	}
 
-	$: if (expanded && visibleEpisodes.length === 0) {
-		// Load initial batch when expanded
-		if (isReversed) {
-			visibleEpisodes = podcast.items.slice(-BATCH_SIZE).reverse();
-		} else {
-			visibleEpisodes = podcast.items.slice(0, BATCH_SIZE);
+	let lastSourceKey = '';
+	$: if (!expanded) {
+		if (visibleEpisodes.length > 0 || lastSourceKey) {
+			lastSourceKey = '';
+			visibleEpisodes = [];
 		}
-		// If there's a currently playing episode in this podcast, load up to it
+	} else if (visibleEpisodes.length === 0 || lastSourceKey !== sourceKey) {
+		lastSourceKey = sourceKey;
+		visibleEpisodes = isReversed
+			? episodeSource.slice(-BATCH_SIZE).reverse()
+			: episodeSource.slice(0, BATCH_SIZE);
 		loadUpToCurrentEpisode();
-	} else if (!expanded) {
-		// Clear episodes when collapsed to free memory
-		visibleEpisodes = [];
 	}
 </script>
 
 <div
-	class="podcast-card {cardStyles.container} {!expanded ? cardStyles.hoverScale : ''}"
+	class="podcast-card min-w-0 overflow-hidden {cardStyles.container} {!expanded ? cardStyles.hoverScale : ''}"
 	data-podcast-id={podcast.id}
 >
 	<FavoriteButton
 		isFavorite={$podcastFavorites[podcast.id]}
 		onClick={() => podcastFavorites.togglePodcast(podcast.id)}
 	/>
-	<div class="collapse collapse-arrow rounded-lg">
+	<div class="collapse collapse-arrow min-w-0 overflow-hidden rounded-lg">
 		<input
 			type="checkbox"
 			aria-label={`${podcast.title} podcast expand button`}
 			checked={expanded}
 			on:change={(e) => onExpand(podcast.id, e.currentTarget.checked)}
 		/>
-		<div class="collapse-title p-0">
-			<div class={cardStyles.content.wrapper}>
+		<div class="collapse-title min-w-0 max-w-full overflow-hidden p-0 pr-8">
+			<div class="{cardStyles.content.wrapper} w-full">
 				<img
 					src={podcast.imageUrl}
 					alt={`${podcast.title} podcast image`}
-					class="{cardStyles.content.image} {imageLoaded ? '' : 'invisible'}"
+					class="{cardStyles.content.image} {imageLoaded ? '' : 'invisible'} shrink-0"
 					loading="lazy"
 					decoding="async"
 					draggable="false"
 					on:load={() => (imageLoaded = true)}
 				/>
-				<div class={cardStyles.content.textContainer}>
-					<h3 class={cardStyles.content.title}>
-						{podcast.title}
-					</h3>
+				<div class="{cardStyles.content.textContainer} min-w-0 overflow-hidden">
+					<div class="flex min-w-0 items-center gap-2">
+						<h3 class="mt-1 min-w-0 flex-1 truncate text-lg font-bold text-base-content">
+							{#if highlightQuery}
+								{#each splitHighlight(podcast.title, highlightQuery) as part}
+									{#if part.hit}<span class="text-primary">{part.text}</span>{:else}{part.text}{/if}
+								{/each}
+							{:else}
+								{podcast.title}
+							{/if}
+						</h3>
+						{#if badgeLabel}
+							<span
+								class="relative z-10 shrink-0 whitespace-nowrap rounded-md bg-primary/25 px-2 py-0.5 text-xs font-medium text-base-content"
+							>
+								{badgeLabel}
+							</span>
+						{/if}
+					</div>
 					<p class={cardStyles.content.description}>
 						{clampText(podcast.description, 120)}
 					</p>
@@ -190,7 +224,16 @@
 							on:click={() => playerStore.playPodcast(podcast, episode)}
 						>
 							<div class="grid grid-cols-[1fr_auto] gap-x-0 gap-y-2">
-								<span class="line-clamp-2 font-medium">{episode.title}</span>
+								<span class="line-clamp-2 font-medium">
+									{#if highlightQuery}
+										{#each splitHighlight(episode.title, highlightQuery) as part}
+											{#if part.hit}<span class="font-semibold text-primary">{part.text}</span
+												>{:else}{part.text}{/if}
+										{/each}
+									{:else}
+										{episode.title}
+									{/if}
+								</span>
 								{#if episode.duration}
 									<div class="text-base-content-secondary text-right text-sm">
 										{formatTime(Number(episode.duration))}
@@ -209,7 +252,7 @@
 							</div>
 						</button>
 					{/each}
-					{#if visibleEpisodes.length < podcast.items.length}
+					{#if visibleEpisodes.length < episodeSource.length}
 						<div class="text-base-content-secondary py-2 text-center text-sm">
 							{$t.home.scrollForMoreEpisodes}
 						</div>

--- a/src/lib/components/PodcastCard.svelte
+++ b/src/lib/components/PodcastCard.svelte
@@ -171,9 +171,11 @@
 					draggable="false"
 					on:load={() => (imageLoaded = true)}
 				/>
-				<div class="{cardStyles.content.textContainer} min-w-0 overflow-hidden">
+				<div class="flex min-h-24 min-w-0 flex-1 items-center overflow-hidden">
 					<div class="flex min-w-0 items-center gap-2">
-						<h3 class="mt-1 min-w-0 flex-1 truncate text-lg font-bold text-base-content">
+						<h3
+							class="min-w-0 flex-1 break-words text-lg font-bold leading-snug text-base-content line-clamp-3"
+						>
 							{#if highlightQuery}
 								{#each splitHighlight(podcast.title, highlightQuery) as part}
 									{#if part.hit}<span class="text-primary">{part.text}</span>{:else}{part.text}{/if}
@@ -190,9 +192,6 @@
 							</span>
 						{/if}
 					</div>
-					<p class={cardStyles.content.description}>
-						{clampText(podcast.description, 120)}
-					</p>
 				</div>
 			</div>
 		</div>

--- a/src/lib/components/utility/SearchInput.svelte
+++ b/src/lib/components/utility/SearchInput.svelte
@@ -5,11 +5,13 @@
 	export let placeholder = '';
 	export let ariaLabel = '';
 	export let clearLabel = '';
+	export let focusOnMount = true;
+	export let onFocus: () => void = () => {};
 
 	let inputEl: HTMLInputElement | undefined;
 
 	function autofocusAction(node: HTMLInputElement) {
-		node.focus();
+		if (focusOnMount) node.focus();
 	}
 
 	function clear() {
@@ -33,6 +35,7 @@
 		spellcheck="false"
 		enterkeyhint="search"
 		bind:value
+		on:focus={onFocus}
 	/>
 	{#if value}
 		<button

--- a/src/lib/components/utility/SearchInput.svelte
+++ b/src/lib/components/utility/SearchInput.svelte
@@ -6,16 +6,25 @@
 	export let ariaLabel = '';
 	export let clearLabel = '';
 
+	let inputEl: HTMLInputElement | undefined;
+
+	function autofocusAction(node: HTMLInputElement) {
+		node.focus();
+	}
+
 	function clear() {
 		value = '';
+		inputEl?.focus();
 	}
 </script>
 
-<label class="relative flex min-h-12 min-w-0 flex-1 items-center">
+<label class="relative flex min-h-10 min-w-0 flex-1 items-center">
 	<Search class="pointer-events-none absolute left-3 h-4 w-4 shrink-0 text-base-content/50" />
 	<input
+		bind:this={inputEl}
+		use:autofocusAction
 		type="text"
-		class="input input-bordered h-12 min-h-12 w-full min-w-0 rounded-lg border-base-300 bg-base-200 pl-10 pr-10 text-base-content select-text"
+		class="input input-bordered h-10 min-h-10 w-full min-w-0 rounded-lg border-base-300 bg-base-200 pl-10 pr-10 text-base-content select-text"
 		style="touch-action: auto; -webkit-user-select: text; user-select: text;"
 		{placeholder}
 		aria-label={ariaLabel || placeholder}

--- a/src/lib/components/utility/SearchInput.svelte
+++ b/src/lib/components/utility/SearchInput.svelte
@@ -7,6 +7,8 @@
 	export let clearLabel = '';
 	export let focusOnMount = true;
 	export let onFocus: () => void = () => {};
+	export let onBlur: () => void = () => {};
+	export let onClear: () => void = () => {};
 
 	let inputEl: HTMLInputElement | undefined;
 
@@ -16,7 +18,17 @@
 
 	function clear() {
 		value = '';
+		onClear();
 		inputEl?.focus();
+	}
+
+	function handleBlur(event: FocusEvent) {
+		const next = event.relatedTarget;
+		if (next instanceof Node && event.currentTarget instanceof HTMLElement) {
+			const root = event.currentTarget.closest('label');
+			if (root?.contains(next)) return;
+		}
+		onBlur();
 	}
 </script>
 
@@ -36,6 +48,7 @@
 		enterkeyhint="search"
 		bind:value
 		on:focus={onFocus}
+		on:blur={handleBlur}
 	/>
 	{#if value}
 		<button

--- a/src/lib/components/utility/SearchInput.svelte
+++ b/src/lib/components/utility/SearchInput.svelte
@@ -5,19 +5,9 @@
 	export let placeholder = '';
 	export let ariaLabel = '';
 	export let clearLabel = '';
-	export let onChange: (value: string) => void = () => {};
 
-	function handleInput(event: Event) {
-		const next = (event.currentTarget as HTMLInputElement).value;
-		value = next;
-		onChange(next);
-	}
-
-	function clear(event: MouseEvent) {
-		event.preventDefault();
-		event.stopPropagation();
+	function clear() {
 		value = '';
-		onChange('');
 	}
 </script>
 
@@ -34,7 +24,6 @@
 		spellcheck="false"
 		enterkeyhint="search"
 		bind:value
-		on:input={handleInput}
 	/>
 	{#if value}
 		<button

--- a/src/lib/components/utility/SearchInput.svelte
+++ b/src/lib/components/utility/SearchInput.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+	import { Search, X } from 'lucide-svelte';
+
+	export let value = '';
+	export let placeholder = '';
+	export let ariaLabel = '';
+	export let clearLabel = '';
+	export let onChange: (value: string) => void = () => {};
+
+	function handleInput(event: Event) {
+		const next = (event.currentTarget as HTMLInputElement).value;
+		value = next;
+		onChange(next);
+	}
+
+	function clear(event: MouseEvent) {
+		event.preventDefault();
+		event.stopPropagation();
+		value = '';
+		onChange('');
+	}
+</script>
+
+<label class="relative flex min-h-12 min-w-0 flex-1 items-center">
+	<Search class="pointer-events-none absolute left-3 h-4 w-4 shrink-0 text-base-content/50" />
+	<input
+		type="text"
+		class="input input-bordered h-12 min-h-12 w-full min-w-0 rounded-lg border-base-300 bg-base-200 pl-10 pr-10 text-base-content select-text"
+		style="touch-action: auto; -webkit-user-select: text; user-select: text;"
+		{placeholder}
+		aria-label={ariaLabel || placeholder}
+		autocomplete="off"
+		autocorrect="off"
+		spellcheck="false"
+		enterkeyhint="search"
+		bind:value
+		on:input={handleInput}
+	/>
+	{#if value}
+		<button
+			type="button"
+			class="absolute right-2 flex h-8 w-8 items-center justify-center rounded-md text-base-content/50 hover:bg-base-300 hover:text-base-content"
+			aria-label={clearLabel || ariaLabel}
+			on:click|stopPropagation|preventDefault={clear}
+		>
+			<X class="h-4 w-4" />
+		</button>
+	{/if}
+</label>

--- a/src/lib/components/utility/VirtualList.svelte
+++ b/src/lib/components/utility/VirtualList.svelte
@@ -339,7 +339,7 @@
 			<div style="height: {topSpacer}px"></div>
 		{/each}
 		{#each items.slice(startIndex, endIndex) as item, i (startIndex + i)}
-			<div style="width: 100%" use:observeRowAction={startIndex + i}>
+			<div style="width: 100%; min-width: 0" use:observeRowAction={startIndex + i}>
 				<slot {item} index={startIndex + i} />
 			</div>
 		{/each}

--- a/src/lib/i18n/langs/en.ts
+++ b/src/lib/i18n/langs/en.ts
@@ -80,7 +80,9 @@ export const en = {
 	},
 	navbar: {
 		goBack: 'Go back',
-		otherLinks: 'Other Links'
+		otherLinks: 'Other Links',
+		search: 'Search',
+		closeSearch: 'Close search'
 	},
 	modals: {
 		externalLinks: 'Other Resources'

--- a/src/lib/i18n/langs/en.ts
+++ b/src/lib/i18n/langs/en.ts
@@ -33,7 +33,8 @@ export const en = {
 		searchClear: 'Clear search',
 		searchNoResults: 'No results found',
 		searchMatchTitle: 'Title',
-		searchMatchEpisodes: '{count} episode',
+		searchMatchEpisode: '1 episode',
+		searchMatchEpisodes: '{count} episodes',
 		searchExactMatches: 'Exact matches',
 		searchSimilarMatches: 'Similar results'
 	},

--- a/src/lib/i18n/langs/en.ts
+++ b/src/lib/i18n/langs/en.ts
@@ -27,7 +27,15 @@ export const en = {
 		allStationsInFavorites: 'All stations are in favorites',
 		allArchiveInFavorites: 'All of this archive is in favorites',
 		scrollForMoreEpisodes: 'Scroll for more episodes',
-		allCategories: 'All'
+		allCategories: 'All',
+		searchPlaceholder: 'Search podcasts or episodes…',
+		searchLabel: 'Search archive',
+		searchClear: 'Clear search',
+		searchNoResults: 'No results found',
+		searchMatchTitle: 'Title',
+		searchMatchEpisodes: '{count} episode',
+		searchExactMatches: 'Exact matches',
+		searchSimilarMatches: 'Similar results'
 	},
 	player: {
 		skipBackward: 'Skip backward',

--- a/src/lib/i18n/langs/tr.ts
+++ b/src/lib/i18n/langs/tr.ts
@@ -28,7 +28,7 @@ export const tr: TranslationType = {
     allStationsInFavorites: 'Tüm istasyonlar favorilerde',
     allArchiveInFavorites: 'Bu arşivin tamamı favorilerde',
     scrollForMoreEpisodes: 'Daha fazla bölüm için kaydırın',
-    allCategories: 'Hepsini Gör',
+    allCategories: 'Tümü',
     searchPlaceholder: 'Podcast veya bölüm ara…',
     searchLabel: 'Arşivde ara',
     searchClear: 'Aramayı temizle',

--- a/src/lib/i18n/langs/tr.ts
+++ b/src/lib/i18n/langs/tr.ts
@@ -28,7 +28,15 @@ export const tr: TranslationType = {
     allStationsInFavorites: 'Tüm istasyonlar favorilerde',
     allArchiveInFavorites: 'Bu arşivin tamamı favorilerde',
     scrollForMoreEpisodes: 'Daha fazla bölüm için kaydırın',
-    allCategories: 'Hepsini Gör'
+    allCategories: 'Hepsini Gör',
+    searchPlaceholder: 'Podcast veya bölüm ara…',
+    searchLabel: 'Arşivde ara',
+    searchClear: 'Aramayı temizle',
+    searchNoResults: 'Sonuç bulunamadı',
+    searchMatchTitle: 'Başlık',
+    searchMatchEpisodes: '{count} Bölüm',
+    searchExactMatches: 'Birebir eşleşmeler',
+    searchSimilarMatches: 'Benzer sonuçlar'
   },
   player: {
     skipBackward: 'Geri atla',

--- a/src/lib/i18n/langs/tr.ts
+++ b/src/lib/i18n/langs/tr.ts
@@ -81,7 +81,9 @@ export const tr: TranslationType = {
   },
   navbar: {
     goBack: 'Geri git',
-    otherLinks: 'Diğer Bağlantılar'
+    otherLinks: 'Diğer Bağlantılar',
+    search: 'Ara',
+    closeSearch: 'Aramayı kapat'
   },
   modals: {
     externalLinks: 'Diğer Kaynaklar'

--- a/src/lib/i18n/langs/tr.ts
+++ b/src/lib/i18n/langs/tr.ts
@@ -34,6 +34,7 @@ export const tr: TranslationType = {
     searchClear: 'Aramayı temizle',
     searchNoResults: 'Sonuç bulunamadı',
     searchMatchTitle: 'Başlık',
+    searchMatchEpisode: '1 Bölüm',
     searchMatchEpisodes: '{count} Bölüm',
     searchExactMatches: 'Birebir eşleşmeler',
     searchSimilarMatches: 'Benzer sonuçlar'

--- a/src/lib/stores/homeSearch.ts
+++ b/src/lib/stores/homeSearch.ts
@@ -1,0 +1,9 @@
+import { get, writable } from 'svelte/store';
+
+export const homeSearchQuery = writable('');
+
+export function clearHomeSearch(): boolean {
+	if (!get(homeSearchQuery).trim()) return false;
+	homeSearchQuery.set('');
+	return true;
+}

--- a/src/lib/stores/homeSearch.ts
+++ b/src/lib/stores/homeSearch.ts
@@ -1,9 +1,0 @@
-import { get, writable } from 'svelte/store';
-
-export const homeSearchQuery = writable('');
-
-export function clearHomeSearch(): boolean {
-	if (!get(homeSearchQuery).trim()) return false;
-	homeSearchQuery.set('');
-	return true;
-}

--- a/src/lib/stores/player.ts
+++ b/src/lib/stores/player.ts
@@ -1,6 +1,7 @@
 import { writable, get } from 'svelte/store';
+import { tick } from 'svelte';
 import { settings } from '$lib/stores/settings';
-import { clearHomeSearch } from '$lib/stores/homeSearch';
+import { clearSearch } from '$lib/stores/search';
 import { goto } from '$app/navigation';
 import { podcasts, type Episode, type Podcast } from '$lib/stores/podcast/podcasts';
 import { radios, type Radio } from '$lib/stores/radio/radios';
@@ -495,8 +496,8 @@ export function restartRadio() {
 // Other player utilities
 export function togglePlaylist(targetPodcastId?: string) {
 	// Player "go to" has no target id; expand/reverse pass one and must keep search.
-	if (targetPodcastId === undefined && clearHomeSearch()) {
-		setTimeout(() => togglePlaylist(), 0);
+	if (targetPodcastId === undefined && clearSearch()) {
+		tick().then(() => togglePlaylist());
 		return;
 	}
 	const state = get(playerStore);

--- a/src/lib/stores/player.ts
+++ b/src/lib/stores/player.ts
@@ -3,6 +3,7 @@ import { tick } from 'svelte';
 import { settings } from '$lib/stores/settings';
 import { clearSearch } from '$lib/stores/search';
 import { goto } from '$app/navigation';
+import { page } from '$app/state';
 import { podcasts, type Episode, type Podcast } from '$lib/stores/podcast/podcasts';
 import { radios, type Radio } from '$lib/stores/radio/radios';
 import { blinkClasses } from '$lib/util/blinkClassess';
@@ -493,6 +494,12 @@ export function restartRadio() {
 	}
 }
 
+function revealOnHome(task: () => Promise<void>): Promise<void> {
+	// goto('/') from home would replace page.state and close search.
+	if (page.url.pathname === '/') return task();
+	return goto('/').then(task);
+}
+
 // Other player utilities
 export function togglePlaylist(targetPodcastId?: string) {
 	// Player "go to" has no target id; expand/reverse pass one and must keep search.
@@ -504,8 +511,7 @@ export function togglePlaylist(targetPodcastId?: string) {
 	const podcastId = targetPodcastId ?? (state.type === 'podcast' ? state.currentPodcast?.id : null);
 
 	if (podcastId) {
-		// Navigate to main page using SvelteKit's goto
-		goto('/').then(async () => {
+		revealOnHome(async () => {
 			// Ask VirtualLists to ensure the podcast is visible and await completion
 			await ensureVisibleById(podcastId);
 
@@ -567,8 +573,7 @@ export function togglePlaylist(targetPodcastId?: string) {
 			}
 		});
 	} else if (state.type === 'radio' && state.currentRadio) {
-		// Navigate to main page using SvelteKit's goto
-		goto('/').then(async () => {
+		revealOnHome(async () => {
 			// Ask VirtualLists to ensure the radio is visible and await completion
 			if (state.currentRadio) {
 				await ensureVisibleById(state.currentRadio.id);

--- a/src/lib/stores/player.ts
+++ b/src/lib/stores/player.ts
@@ -1,5 +1,6 @@
 import { writable, get } from 'svelte/store';
 import { settings } from '$lib/stores/settings';
+import { clearHomeSearch } from '$lib/stores/homeSearch';
 import { goto } from '$app/navigation';
 import { podcasts, type Episode, type Podcast } from '$lib/stores/podcast/podcasts';
 import { radios, type Radio } from '$lib/stores/radio/radios';
@@ -493,6 +494,11 @@ export function restartRadio() {
 
 // Other player utilities
 export function togglePlaylist(targetPodcastId?: string) {
+	// Player "go to" has no target id; expand/reverse pass one and must keep search.
+	if (targetPodcastId === undefined && clearHomeSearch()) {
+		setTimeout(() => togglePlaylist(), 0);
+		return;
+	}
 	const state = get(playerStore);
 	const podcastId = targetPodcastId ?? (state.type === 'podcast' ? state.currentPodcast?.id : null);
 

--- a/src/lib/stores/podcast/podcasts.ts
+++ b/src/lib/stores/podcast/podcasts.ts
@@ -43,8 +43,10 @@ export async function getPodcastRssUrls() {
 		7
 	);
 	const text = await res.text();
-	const urls = text.split('\n').map((url) => url.trim());
-	return urls;
+	return text
+		.split('\n')
+		.map((url) => url.trim())
+		.filter((url) => url.length > 0 && !url.startsWith('#'));
 }
 
 export async function fetchPodcast(url: string): Promise<Podcast | null> {

--- a/src/lib/stores/search.ts
+++ b/src/lib/stores/search.ts
@@ -1,0 +1,38 @@
+import { browser } from '$app/environment';
+import { pushState, replaceState } from '$app/navigation';
+import { page } from '$app/stores';
+import { derived, get, writable } from 'svelte/store';
+
+export const searchQuery = writable('');
+export const searchOpen = derived(page, ($page) => !!$page.state.search);
+
+function pageState(): App.PageState {
+	return get(page).state;
+}
+
+export function openSearch() {
+	if (browser && !get(searchOpen)) {
+		// TWA/Android back should dismiss search instead of leaving the page.
+		pushState('', { ...pageState(), search: true });
+	}
+}
+
+export function closeSearch(options?: { popHistory?: boolean }) {
+	const popHistory = options?.popHistory ?? true;
+	const wasOpen = get(searchOpen);
+	searchQuery.set('');
+	if (!wasOpen || !browser) return;
+	if (popHistory) {
+		history.back();
+	} else {
+		replaceState('', { ...pageState(), search: false });
+	}
+}
+
+export function clearSearch(): boolean {
+	const hadQuery = get(searchQuery).trim().length > 0;
+	const wasOpen = get(searchOpen);
+	if (!hadQuery && !wasOpen) return false;
+	closeSearch();
+	return true;
+}

--- a/src/lib/util/search.ts
+++ b/src/lib/util/search.ts
@@ -1,0 +1,340 @@
+import type { Podcast } from '$lib/stores/podcast/podcasts';
+
+export type MatchField = 'title' | 'episode';
+export type MatchKind = 'exact' | 'similar';
+
+export interface SearchHit {
+	podcast: Podcast;
+	score: number;
+	matchField: MatchField;
+	matchKind: MatchKind;
+	matchedEpisodeIds: string[];
+}
+
+interface FoldedPodcast {
+	title: string;
+	episodes: { id: string; title: string }[];
+}
+
+interface FoldMap {
+	folded: string;
+	origIndex: number[];
+}
+
+const foldedCache = new WeakMap<Podcast, FoldedPodcast>();
+
+const CHAR_FOLD: Record<string, string> = {
+	ş: 's',
+	ğ: 'g',
+	ü: 'u',
+	ö: 'o',
+	ç: 'c',
+	ı: 'i',
+	â: 'a',
+	î: 'i',
+	û: 'u'
+};
+
+const APOSTROPHES = /[''`´ʼʾʿ]/;
+const FIELD_WEIGHT: Record<MatchField, number> = {
+	title: 3,
+	episode: 1
+};
+const FIELD_ORDER: MatchField[] = ['title', 'episode'];
+
+function asText(value: unknown): string {
+	if (value == null) return '';
+	if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+		return String(value);
+	}
+	if (Array.isArray(value)) return value.map(asText).join(' ');
+	if (typeof value === 'object') {
+		const obj = value as Record<string, unknown>;
+		return Object.values(obj).map(asText).join(' ');
+	}
+	return '';
+}
+
+function stripHtml(input: string): string {
+	return input.replace(/<[^>]*>/g, ' ');
+}
+
+function foldChar(char: string): string {
+	let c = char.toLocaleLowerCase('tr');
+	c = CHAR_FOLD[c] ?? c;
+	c = c.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+	if (!c) return '';
+	if (APOSTROPHES.test(c)) return '';
+	if (!/[0-9a-z]/i.test(c) && c.toLowerCase() === c.toUpperCase()) return ' ';
+	return c;
+}
+
+function foldMapped(input: string): FoldMap {
+	let folded = '';
+	const origIndex: number[] = [];
+	let lastWasSpace = true;
+
+	for (let i = 0; i < input.length; i++) {
+		const out = foldChar(input[i]);
+		for (const ch of out) {
+			if (ch === ' ') {
+				if (lastWasSpace) continue;
+				lastWasSpace = true;
+				folded += ' ';
+				origIndex.push(i);
+			} else {
+				lastWasSpace = false;
+				folded += ch;
+				origIndex.push(i);
+			}
+		}
+	}
+
+	if (folded.endsWith(' ')) {
+		folded = folded.slice(0, -1);
+		origIndex.pop();
+	}
+
+	return { folded, origIndex };
+}
+
+/** Fold text so Turkish/English variants match (ş↔s, ı↔i, Kur'an↔kuran, …). */
+export function fold(input: unknown): string {
+	const text = stripHtml(asText(input));
+	if (!text) return '';
+	return foldMapped(text).folded;
+}
+
+type TokenKind = 'exact' | 'prefix' | 'infix' | 'fuzzy';
+
+const TOKEN_SCORE: Record<TokenKind, number> = {
+	exact: 1,
+	prefix: 0.9,
+	infix: 0.85,
+	fuzzy: 0.5
+};
+
+function isWordBoundary(haystack: string, idx: number): boolean {
+	return idx === 0 || haystack[idx - 1] === ' ';
+}
+
+function isEndBoundary(haystack: string, endIdx: number): boolean {
+	return endIdx === haystack.length || haystack[endIdx] === ' ';
+}
+
+function kindRank(kind: MatchKind | null): number {
+	if (kind === 'exact') return 2;
+	if (kind === 'similar') return 1;
+	return 0;
+}
+
+function isEditDistanceOne(a: string, b: string): boolean {
+	if (a === b) return false;
+	const la = a.length;
+	const lb = b.length;
+	if (Math.abs(la - lb) > 1) return false;
+
+	if (la === lb) {
+		let diff = 0;
+		for (let i = 0; i < la; i++) {
+			if (a[i] !== b[i] && ++diff > 1) return false;
+		}
+		return diff === 1;
+	}
+
+	const shorter = la < lb ? a : b;
+	const longer = la < lb ? b : a;
+	let i = 0;
+	let j = 0;
+	let skipped = false;
+	while (i < shorter.length && j < longer.length) {
+		if (shorter[i] === longer[j]) {
+			i++;
+			j++;
+		} else if (skipped) {
+			return false;
+		} else {
+			skipped = true;
+			j++;
+		}
+	}
+	return true;
+}
+
+function wordEditDistanceOne(haystack: string, query: string): boolean {
+	if (query.length < 5) return false;
+	for (const word of haystack.split(' ')) {
+		if (isEditDistanceOne(word, query)) return true;
+	}
+	return false;
+}
+
+function tokenKind(haystack: string, query: string): TokenKind | null {
+	if (!query || !haystack) return null;
+
+	let foundPrefix = false;
+	let foundInfix = false;
+	let from = 0;
+	while (from <= haystack.length - query.length) {
+		const idx = haystack.indexOf(query, from);
+		if (idx === -1) break;
+		const atStart = isWordBoundary(haystack, idx);
+		const atEnd = isEndBoundary(haystack, idx + query.length);
+		if (atStart && atEnd) return 'exact';
+		if (atStart) foundPrefix = true;
+		else if (query.length > 1) foundInfix = true;
+		from = idx + 1;
+	}
+	if (foundPrefix) return 'prefix';
+	if (foundInfix) return 'infix';
+	if (wordEditDistanceOne(haystack, query)) return 'fuzzy';
+	return null;
+}
+
+function toMatchKind(kind: TokenKind | null): MatchKind | null {
+	if (!kind) return null;
+	return kind === 'exact' ? 'exact' : 'similar';
+}
+
+function scoreText(
+	haystack: string,
+	foldedQuery: string,
+	tokens: string[]
+): { score: number; kind: MatchKind | null } {
+	if (!foldedQuery || !haystack) return { score: 0, kind: null };
+
+	const whole = tokenKind(haystack, foldedQuery);
+	if (tokens.length <= 1) {
+		return { score: whole ? TOKEN_SCORE[whole] : 0, kind: toMatchKind(whole) };
+	}
+
+	const kinds: TokenKind[] = [];
+	for (const token of tokens) {
+		const kind = tokenKind(haystack, token);
+		if (!kind) {
+			return { score: whole ? TOKEN_SCORE[whole] : 0, kind: toMatchKind(whole) };
+		}
+		kinds.push(kind);
+	}
+
+	const avg = kinds.reduce((sum, kind) => sum + TOKEN_SCORE[kind], 0) / kinds.length;
+	const wholeScore = whole ? TOKEN_SCORE[whole] : 0;
+	const kind: MatchKind =
+		whole === 'exact' || kinds.every((item) => item === 'exact') ? 'exact' : 'similar';
+	return { score: Math.max(wholeScore, avg), kind };
+}
+
+function getFoldedPodcast(podcast: Podcast): FoldedPodcast {
+	const cached = foldedCache.get(podcast);
+	if (cached) return cached;
+
+	const folded: FoldedPodcast = {
+		title: fold(podcast.title),
+		episodes: (podcast.items ?? []).map((episode) => ({
+			id: episode.id,
+			title: fold(episode.title)
+		}))
+	};
+	foldedCache.set(podcast, folded);
+	return folded;
+}
+
+export interface HighlightPart {
+	text: string;
+	hit: boolean;
+}
+
+/** Split `original` into parts so the query match can be emphasized in the UI. */
+export function splitHighlight(original: unknown, query: string): HighlightPart[] {
+	const text = asText(original);
+	if (!text) return [];
+	const foldedQuery = fold(query);
+	if (!foldedQuery) return [{ text, hit: false }];
+
+	const { folded, origIndex } = foldMapped(text);
+	if (!folded || origIndex.length === 0) return [{ text, hit: false }];
+
+	let startFold = folded.indexOf(foldedQuery);
+	let endFold = startFold >= 0 ? startFold + foldedQuery.length : -1;
+
+	if (startFold < 0) {
+		for (const token of foldedQuery.split(' ').filter(Boolean)) {
+			const idx = folded.indexOf(token);
+			if (idx < 0) continue;
+			if (token.length === 1 && !isWordBoundary(folded, idx)) continue;
+			startFold = idx;
+			endFold = idx + token.length;
+			break;
+		}
+	}
+
+	if (startFold < 0) return [{ text, hit: false }];
+
+	const origStart = origIndex[startFold];
+	const lastOrig = origIndex[endFold - 1];
+	let origEnd = lastOrig + 1;
+	while (origEnd < text.length && /[\u0300-\u036f]/.test(text[origEnd])) origEnd++;
+
+	const parts: HighlightPart[] = [];
+	if (origStart > 0) parts.push({ text: text.slice(0, origStart), hit: false });
+	parts.push({ text: text.slice(origStart, origEnd), hit: true });
+	if (origEnd < text.length) parts.push({ text: text.slice(origEnd), hit: false });
+	return parts;
+}
+
+export function searchPodcasts(podcasts: Podcast[], query: string): SearchHit[] {
+	const foldedQuery = fold(query);
+	if (!foldedQuery) return [];
+
+	const tokens = foldedQuery.split(' ').filter(Boolean);
+
+	const hits: (SearchHit & { index: number })[] = [];
+	for (let index = 0; index < podcasts.length; index++) {
+		const podcast = podcasts[index];
+		try {
+			const folded = getFoldedPodcast(podcast);
+			const titleMatch = scoreText(folded.title, foldedQuery, tokens);
+
+			let bestEpisodeScore = 0;
+			let bestEpisodeKind: MatchKind | null = null;
+			const matchedEpisodeIds: string[] = [];
+			for (const episode of folded.episodes) {
+				const episodeMatch = scoreText(episode.title, foldedQuery, tokens);
+				if (episodeMatch.score > 0) {
+					matchedEpisodeIds.push(episode.id);
+					if (episodeMatch.score > bestEpisodeScore) bestEpisodeScore = episodeMatch.score;
+					if (kindRank(episodeMatch.kind) > kindRank(bestEpisodeKind)) {
+						bestEpisodeKind = episodeMatch.kind;
+					}
+				}
+			}
+
+			let matchField: MatchField | null = null;
+			if (titleMatch.score > 0) matchField = 'title';
+			else if (bestEpisodeScore > 0) matchField = 'episode';
+			if (!matchField) continue;
+
+			const matchKind: MatchKind =
+				titleMatch.kind === 'exact' || bestEpisodeKind === 'exact' ? 'exact' : 'similar';
+			const score = Math.max(
+				titleMatch.score * FIELD_WEIGHT.title,
+				bestEpisodeScore * FIELD_WEIGHT.episode
+			);
+
+			hits.push({ podcast, score, matchField, matchKind, matchedEpisodeIds, index });
+		} catch (error) {
+			console.error(`Search failed for podcast ${asText(podcast?.id) || podcast?.title}`, error);
+		}
+	}
+
+	hits.sort((a, b) => {
+		const kindDelta = kindRank(b.matchKind) - kindRank(a.matchKind);
+		if (kindDelta !== 0) return kindDelta;
+		const fieldDelta = FIELD_ORDER.indexOf(a.matchField) - FIELD_ORDER.indexOf(b.matchField);
+		if (fieldDelta !== 0) return fieldDelta;
+		if (b.score !== a.score) return b.score - a.score;
+		return a.index - b.index;
+	});
+
+	return hits.map(({ index: _index, ...hit }) => hit);
+}

--- a/src/lib/util/search.ts
+++ b/src/lib/util/search.ts
@@ -161,12 +161,49 @@ function isEditDistanceOne(a: string, b: string): boolean {
 	return true;
 }
 
-function wordEditDistanceOne(haystack: string, query: string): boolean {
-	if (query.length < 5) return false;
-	for (const word of haystack.split(' ')) {
-		if (isEditDistanceOne(word, query)) return true;
+function mergeFoldRanges(ranges: [number, number][]): [number, number][] {
+	if (ranges.length === 0) return [];
+	ranges.sort((a, b) => a[0] - b[0]);
+	const merged: [number, number][] = [];
+	for (const range of ranges) {
+		const last = merged.at(-1);
+		if (last && range[0] <= last[1]) last[1] = Math.max(last[1], range[1]);
+		else merged.push([range[0], range[1]]);
 	}
-	return false;
+	return merged;
+}
+
+function findSubstringRanges(haystack: string, needle: string): [number, number][] {
+	if (!needle) return [];
+	const ranges: [number, number][] = [];
+	let from = 0;
+	while (from <= haystack.length - needle.length) {
+		const idx = haystack.indexOf(needle, from);
+		if (idx === -1) break;
+		if (needle.length > 1 || isWordBoundary(haystack, idx)) {
+			ranges.push([idx, idx + needle.length]);
+		}
+		from = idx + 1;
+	}
+	return ranges;
+}
+
+function findFuzzyWordRanges(haystack: string, query: string): [number, number][] {
+	if (query.length < 5) return [];
+	const ranges: [number, number][] = [];
+	let start = 0;
+	for (let i = 0; i <= haystack.length; i++) {
+		if (i < haystack.length && haystack[i] !== ' ') continue;
+		if (i > start && isEditDistanceOne(haystack.slice(start, i), query)) {
+			ranges.push([start, i]);
+		}
+		start = i + 1;
+	}
+	return ranges;
+}
+
+function findNeedleRanges(haystack: string, needle: string): [number, number][] {
+	return [...findSubstringRanges(haystack, needle), ...findFuzzyWordRanges(haystack, needle)];
 }
 
 function tokenKind(haystack: string, query: string): TokenKind | null {
@@ -174,20 +211,16 @@ function tokenKind(haystack: string, query: string): TokenKind | null {
 
 	let foundPrefix = false;
 	let foundInfix = false;
-	let from = 0;
-	while (from <= haystack.length - query.length) {
-		const idx = haystack.indexOf(query, from);
-		if (idx === -1) break;
+	for (const [idx, end] of findSubstringRanges(haystack, query)) {
 		const atStart = isWordBoundary(haystack, idx);
-		const atEnd = isEndBoundary(haystack, idx + query.length);
+		const atEnd = isEndBoundary(haystack, end);
 		if (atStart && atEnd) return 'exact';
 		if (atStart) foundPrefix = true;
 		else if (query.length > 1) foundInfix = true;
-		from = idx + 1;
 	}
 	if (foundPrefix) return 'prefix';
 	if (foundInfix) return 'infix';
-	if (wordEditDistanceOne(haystack, query)) return 'fuzzy';
+	if (findFuzzyWordRanges(haystack, query).length > 0) return 'fuzzy';
 	return null;
 }
 
@@ -254,31 +287,26 @@ export function splitHighlight(original: unknown, query: string): HighlightPart[
 	const { folded, origIndex } = foldMapped(text);
 	if (!folded || origIndex.length === 0) return [{ text, hit: false }];
 
-	let startFold = folded.indexOf(foldedQuery);
-	let endFold = startFold >= 0 ? startFold + foldedQuery.length : -1;
-
-	if (startFold < 0) {
-		for (const token of foldedQuery.split(' ').filter(Boolean)) {
-			const idx = folded.indexOf(token);
-			if (idx < 0) continue;
-			if (token.length === 1 && !isWordBoundary(folded, idx)) continue;
-			startFold = idx;
-			endFold = idx + token.length;
-			break;
-		}
+	const needles = [foldedQuery, ...foldedQuery.split(' ').filter(Boolean)];
+	const foldRanges: [number, number][] = [];
+	for (const needle of new Set(needles)) {
+		foldRanges.push(...findNeedleRanges(folded, needle));
 	}
 
-	if (startFold < 0) return [{ text, hit: false }];
-
-	const origStart = origIndex[startFold];
-	const lastOrig = origIndex[endFold - 1];
-	let origEnd = lastOrig + 1;
-	while (origEnd < text.length && /[\u0300-\u036f]/.test(text[origEnd])) origEnd++;
+	const merged = mergeFoldRanges(foldRanges);
+	if (merged.length === 0) return [{ text, hit: false }];
 
 	const parts: HighlightPart[] = [];
-	if (origStart > 0) parts.push({ text: text.slice(0, origStart), hit: false });
-	parts.push({ text: text.slice(origStart, origEnd), hit: true });
-	if (origEnd < text.length) parts.push({ text: text.slice(origEnd), hit: false });
+	let cursor = 0;
+	for (const [startFold, endFold] of merged) {
+		const origStart = origIndex[startFold];
+		let origEnd = origIndex[endFold - 1] + 1;
+		while (origEnd < text.length && /[\u0300-\u036f]/.test(text[origEnd])) origEnd++;
+		if (origStart > cursor) parts.push({ text: text.slice(cursor, origStart), hit: false });
+		parts.push({ text: text.slice(origStart, origEnd), hit: true });
+		cursor = origEnd;
+	}
+	if (cursor < text.length) parts.push({ text: text.slice(cursor), hit: false });
 	return parts;
 }
 
@@ -309,8 +337,12 @@ export function searchPodcasts(podcasts: Podcast[], query: string): SearchHit[] 
 				}
 			}
 
+			const titleKindRank = kindRank(titleMatch.kind);
+			const episodeKindRank = kindRank(bestEpisodeKind);
 			let matchField: MatchField | null = null;
-			if (titleMatch.score > 0) matchField = 'title';
+			if (titleKindRank > episodeKindRank) matchField = 'title';
+			else if (episodeKindRank > titleKindRank) matchField = 'episode';
+			else if (titleMatch.score > 0) matchField = 'title';
 			else if (bestEpisodeScore > 0) matchField = 'episode';
 			if (!matchField) continue;
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -27,7 +27,7 @@
 		</div>
 	</div>
 
-	<div class="{outerDivStyle} grow overflow-y-auto overflow-x-hidden">
+	<div class="{outerDivStyle} grow overflow-y-auto overflow-x-hidden" data-main-scroller>
 		<div class="{innerDivStyle} space-y-1 px-3 py-2 sm:py-3 sm:py-5">
 			<slot></slot>
 		</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,6 @@
 	import { radioFavorites } from '$lib/stores/radio/radioFavorites';
 	import { podcastFavorites } from '$lib/stores/podcast/podcastFavorites';
 	import DropdownSelect from '$lib/components/utility/DropdownSelect.svelte';
-	import SearchInput from '$lib/components/utility/SearchInput.svelte';
 	import { config } from '$lib/config';
 	import { togglePlaylist } from '$lib/stores/player';
 	import { radios, type Radio } from '$lib/stores/radio/radios';
@@ -17,7 +16,7 @@
 	import { get } from 'svelte/store';
 	import VirtualList from '$lib/components/utility/VirtualList.svelte';
 	import { searchPodcasts, type SearchHit } from '$lib/util/search';
-	import { homeSearchQuery } from '$lib/stores/homeSearch';
+	import { searchQuery } from '$lib/stores/search';
 
 	let expandedPodcasts = new Set<string>();
 	let headerClasses = 'mb-2 sm:mb-4';
@@ -52,7 +51,7 @@
 	$: otherRadios = $radios.filter((radio) => !$radioFavorites[radio.title]);
 	$: favoritePodcasts = $podcasts.filter((podcast) => !!$podcastFavorites[podcast.id]);
 
-	$: isSearching = $homeSearchQuery.trim().length > 0;
+	$: isSearching = $searchQuery.trim().length > 0;
 	$: categoryPodcasts =
 		selectedCategory === ALL_CATEGORY
 			? $podcasts
@@ -60,7 +59,7 @@
 	$: filteredPodcasts = categoryPodcasts.filter((podcast) => !$podcastFavorites[podcast.id]);
 	$: otherPodcasts = filteredPodcasts;
 	$: searchHits = isSearching
-		? searchPodcasts(categoryPodcasts, $homeSearchQuery)
+		? searchPodcasts(categoryPodcasts, $searchQuery)
 		: [];
 	$: searchHitById = new Map(searchHits.map((hit) => [hit.podcast.id, hit]));
 	$: exactPodcasts = searchHits.filter((hit) => hit.matchKind === 'exact').map((hit) => hit.podcast);
@@ -69,13 +68,12 @@
 		.map((hit) => hit.podcast);
 	$: archivePodcasts = isSearching ? searchHits.map((hit) => hit.podcast) : otherPodcasts;
 
-	$: if ($homeSearchQuery !== lastSearchKey) {
-		lastSearchKey = $homeSearchQuery;
+	$: if ($searchQuery !== lastSearchKey) {
+		lastSearchKey = $searchQuery;
 		expandedPodcasts = new Set();
 	}
 
-	$: if (typeof window !== 'undefined') {
-		void $homeSearchQuery;
+	$: if (typeof window !== 'undefined' && $searchQuery.trim()) {
 		queueMicrotask(() => {
 			const scroller = document.querySelector<HTMLElement>('.grow.overflow-y-auto');
 			scroller?.scrollTo({ top: 0 });
@@ -201,27 +199,15 @@
 	<div class="divider"></div>
 {/if}
 
-<h2 class="{headerTextClasses} mb-2">{$t.home.archive}</h2>
-<div
-	class="sticky top-0 z-30 -mx-3 flex items-center gap-2 bg-base-100/95 px-3 py-2 pb-3 backdrop-blur-sm sm:pb-4"
->
-	<div class="min-w-0 flex-1">
-		<SearchInput
-			bind:value={$homeSearchQuery}
-			placeholder={$t.home.searchPlaceholder}
-			ariaLabel={$t.home.searchLabel}
-			clearLabel={$t.home.searchClear}
-		/>
-	</div>
-	<div class="shrink-0">
-		<DropdownSelect
-			value={$settings.selectedCategory}
-			onChange={(value) => settings.updateSettings({ selectedCategory: value })}
-			options={categoryOptions}
-			backgroundColor="bg-base-200"
-			specialFirstOption={true}
-		/>
-	</div>
+<div class="flex items-center justify-between {headerClasses}">
+	<h2 class={[headerTextClasses]}>{$t.home.archive}</h2>
+	<DropdownSelect
+		value={$settings.selectedCategory}
+		onChange={(value) => settings.updateSettings({ selectedCategory: value })}
+		options={categoryOptions}
+		backgroundColor="bg-base-200"
+		specialFirstOption={true}
+	/>
 </div>
 {#snippet podcastGrid(items: Podcast[])}
 	<div class={sectionClasses}>
@@ -235,7 +221,7 @@
 					onExpand={handlePodcastExpand}
 					matchField={hit?.matchField}
 					matchedEpisodeIds={hit?.matchedEpisodeIds}
-					highlightQuery={isSearching ? $homeSearchQuery : ''}
+					highlightQuery={isSearching ? $searchQuery : ''}
 				/>
 			</svelte:fragment>
 		</VirtualList>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -17,15 +17,14 @@
 	import { get } from 'svelte/store';
 	import VirtualList from '$lib/components/utility/VirtualList.svelte';
 	import { searchPodcasts, type SearchHit } from '$lib/util/search';
+	import { homeSearchQuery } from '$lib/stores/homeSearch';
 
 	let expandedPodcasts = new Set<string>();
 	let headerClasses = 'mb-2 sm:mb-4';
 	let headerTextClasses = 'text-2xl font-bold';
 	let sectionClasses = 'grid grid-cols-1 items-start gap-2 sm:gap-4 lg:grid-cols-2 2xl:grid-cols-3';
-	let filteredPodcasts: Podcast[] = [];
 	const ALL_CATEGORY = 'All'; // Keep this as a constant for comparison
 
-	let searchQuery = '';
 	let lastSearchKey = '';
 
 	let sharedPodcastId: string | null = null;
@@ -36,15 +35,6 @@
 
 	// Create a locale-aware sorter based on the current language
 	$: localeSorter = new Intl.Collator($settings.language, { sensitivity: 'base' });
-
-	$: {
-		filteredPodcasts = $podcasts.filter((podcast) => !$podcastFavorites[podcast.id]);
-		if (selectedCategory !== ALL_CATEGORY) {
-			filteredPodcasts = filteredPodcasts.filter((podcast) => {
-				return podcast.categories.includes(selectedCategory);
-			});
-		}
-	}
 
 	$: selectedCategory = $settings.selectedCategory;
 	$: categoryList = [
@@ -61,15 +51,16 @@
 	$: favoriteRadios = $radios.filter((radio) => !!$radioFavorites[radio.title]);
 	$: otherRadios = $radios.filter((radio) => !$radioFavorites[radio.title]);
 	$: favoritePodcasts = $podcasts.filter((podcast) => !!$podcastFavorites[podcast.id]);
-	$: otherPodcasts = filteredPodcasts;
 
-	$: isSearching = searchQuery.trim().length > 0;
+	$: isSearching = $homeSearchQuery.trim().length > 0;
 	$: categoryPodcasts =
 		selectedCategory === ALL_CATEGORY
 			? $podcasts
 			: $podcasts.filter((podcast) => podcast.categories.includes(selectedCategory));
+	$: filteredPodcasts = categoryPodcasts.filter((podcast) => !$podcastFavorites[podcast.id]);
+	$: otherPodcasts = filteredPodcasts;
 	$: searchHits = isSearching
-		? searchPodcasts(categoryPodcasts, searchQuery)
+		? searchPodcasts(categoryPodcasts, $homeSearchQuery)
 		: [];
 	$: searchHitById = new Map(searchHits.map((hit) => [hit.podcast.id, hit]));
 	$: exactPodcasts = searchHits.filter((hit) => hit.matchKind === 'exact').map((hit) => hit.podcast);
@@ -78,21 +69,17 @@
 		.map((hit) => hit.podcast);
 	$: archivePodcasts = isSearching ? searchHits.map((hit) => hit.podcast) : otherPodcasts;
 
-	$: if (searchQuery !== lastSearchKey) {
-		lastSearchKey = searchQuery;
+	$: if ($homeSearchQuery !== lastSearchKey) {
+		lastSearchKey = $homeSearchQuery;
 		expandedPodcasts = new Set();
 	}
 
 	$: if (typeof window !== 'undefined') {
-		void searchQuery;
+		void $homeSearchQuery;
 		queueMicrotask(() => {
 			const scroller = document.querySelector<HTMLElement>('.grow.overflow-y-auto');
 			scroller?.scrollTo({ top: 0 });
 		});
-	}
-
-	function handleSearchChange(value: string) {
-		searchQuery = value;
 	}
 
 	function searchMatch(podcast: Podcast): SearchHit | undefined {
@@ -220,11 +207,10 @@
 >
 	<div class="min-w-0 flex-1">
 		<SearchInput
-			bind:value={searchQuery}
+			bind:value={$homeSearchQuery}
 			placeholder={$t.home.searchPlaceholder}
 			ariaLabel={$t.home.searchLabel}
 			clearLabel={$t.home.searchClear}
-			onChange={handleSearchChange}
 		/>
 	</div>
 	<div class="shrink-0">
@@ -249,7 +235,7 @@
 					onExpand={handlePodcastExpand}
 					matchField={hit?.matchField}
 					matchedEpisodeIds={hit?.matchedEpisodeIds}
-					highlightQuery={isSearching ? searchQuery : ''}
+					highlightQuery={isSearching ? $homeSearchQuery : ''}
 				/>
 			</svelte:fragment>
 		</VirtualList>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -75,7 +75,7 @@
 
 	$: if (typeof window !== 'undefined' && $searchQuery.trim()) {
 		queueMicrotask(() => {
-			const scroller = document.querySelector<HTMLElement>('.grow.overflow-y-auto');
+			const scroller = document.querySelector<HTMLElement>('[data-main-scroller]');
 			scroller?.scrollTo({ top: 0 });
 		});
 	}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,15 +6,17 @@
 	import { radioFavorites } from '$lib/stores/radio/radioFavorites';
 	import { podcastFavorites } from '$lib/stores/podcast/podcastFavorites';
 	import DropdownSelect from '$lib/components/utility/DropdownSelect.svelte';
+	import SearchInput from '$lib/components/utility/SearchInput.svelte';
 	import { config } from '$lib/config';
 	import { togglePlaylist } from '$lib/stores/player';
 	import { radios, type Radio } from '$lib/stores/radio/radios';
 	import { podcasts, type Podcast } from '$lib/stores/podcast/podcasts';
 	import { t } from '$lib/i18n';
 	import { playerStore } from '$lib/stores/player';
-	import { onMount, tick } from 'svelte';
+	import { onMount } from 'svelte';
 	import { get } from 'svelte/store';
 	import VirtualList from '$lib/components/utility/VirtualList.svelte';
+	import { searchPodcasts, type SearchHit } from '$lib/util/search';
 
 	let expandedPodcasts = new Set<string>();
 	let headerClasses = 'mb-2 sm:mb-4';
@@ -22,6 +24,9 @@
 	let sectionClasses = 'grid grid-cols-1 items-start gap-2 sm:gap-4 lg:grid-cols-2 2xl:grid-cols-3';
 	let filteredPodcasts: Podcast[] = [];
 	const ALL_CATEGORY = 'All'; // Keep this as a constant for comparison
+
+	let searchQuery = '';
+	let lastSearchKey = '';
 
 	let sharedPodcastId: string | null = null;
 	let sharedEpisodeId: string | null = null;
@@ -57,6 +62,42 @@
 	$: otherRadios = $radios.filter((radio) => !$radioFavorites[radio.title]);
 	$: favoritePodcasts = $podcasts.filter((podcast) => !!$podcastFavorites[podcast.id]);
 	$: otherPodcasts = filteredPodcasts;
+
+	$: isSearching = searchQuery.trim().length > 0;
+	$: categoryPodcasts =
+		selectedCategory === ALL_CATEGORY
+			? $podcasts
+			: $podcasts.filter((podcast) => podcast.categories.includes(selectedCategory));
+	$: searchHits = isSearching
+		? searchPodcasts(categoryPodcasts, searchQuery)
+		: [];
+	$: searchHitById = new Map(searchHits.map((hit) => [hit.podcast.id, hit]));
+	$: exactPodcasts = searchHits.filter((hit) => hit.matchKind === 'exact').map((hit) => hit.podcast);
+	$: similarPodcasts = searchHits
+		.filter((hit) => hit.matchKind === 'similar')
+		.map((hit) => hit.podcast);
+	$: archivePodcasts = isSearching ? searchHits.map((hit) => hit.podcast) : otherPodcasts;
+
+	$: if (searchQuery !== lastSearchKey) {
+		lastSearchKey = searchQuery;
+		expandedPodcasts = new Set();
+	}
+
+	$: if (typeof window !== 'undefined') {
+		void searchQuery;
+		queueMicrotask(() => {
+			const scroller = document.querySelector<HTMLElement>('.grow.overflow-y-auto');
+			scroller?.scrollTo({ top: 0 });
+		});
+	}
+
+	function handleSearchChange(value: string) {
+		searchQuery = value;
+	}
+
+	function searchMatch(podcast: Podcast): SearchHit | undefined {
+		return searchHitById.get(podcast.id);
+	}
 
 	function tryHandleShare() {
 		if (sharedPodcastId) {
@@ -133,70 +174,112 @@
 	}
 </script>
 
-{#if favoriteRadios.length > 0 || favoritePodcasts.length > 0}
-	<h2 class={[headerClasses, headerTextClasses]}>{$t.home.favorites}</h2>
+{#if !isSearching}
+	{#if favoriteRadios.length > 0 || favoritePodcasts.length > 0}
+		<h2 class={[headerClasses, headerTextClasses]}>{$t.home.favorites}</h2>
+		<div class={sectionClasses}>
+			{#each favoriteRadios as radio (radio.title)}
+				<RadioCard {radio} />
+			{/each}
+			<VirtualList items={favoritePodcasts} estimatedItemHeight={97.5}>
+				<svelte:fragment let:item>
+					<PodcastCard
+						podcast={item as Podcast}
+						expanded={expandedPodcasts.has((item as Podcast).id)}
+						onExpand={handlePodcastExpand}
+					/>
+				</svelte:fragment>
+			</VirtualList>
+		</div>
+		<div class="divider"></div>
+	{/if}
+
+	<h2 class={[headerClasses, headerTextClasses]}>{$t.home.radio}</h2>
 	<div class={sectionClasses}>
-		{#each favoriteRadios as radio (radio.title)}
-			<RadioCard {radio} />
-		{/each}
-		<VirtualList items={favoritePodcasts} estimatedItemHeight={97.5}>
+		{#if $radios.length === 0}
+			{#each Array(4) as _}
+				<SkeletonCard />
+			{/each}
+		{:else if otherRadios.length === 0}
+			<p class="text-base-content-secondary">{$t.home.allStationsInFavorites}</p>
+		{:else}
+			<VirtualList items={otherRadios} estimatedItemHeight={97.5}>
+				<svelte:fragment let:item>
+					<RadioCard radio={item as Radio} />
+				</svelte:fragment>
+			</VirtualList>
+		{/if}
+	</div>
+
+	<div class="divider"></div>
+{/if}
+
+<h2 class="{headerTextClasses} mb-2">{$t.home.archive}</h2>
+<div
+	class="sticky top-0 z-30 -mx-3 flex items-center gap-2 bg-base-100/95 px-3 py-2 pb-3 backdrop-blur-sm sm:pb-4"
+>
+	<div class="min-w-0 flex-1">
+		<SearchInput
+			bind:value={searchQuery}
+			placeholder={$t.home.searchPlaceholder}
+			ariaLabel={$t.home.searchLabel}
+			clearLabel={$t.home.searchClear}
+			onChange={handleSearchChange}
+		/>
+	</div>
+	<div class="shrink-0">
+		<DropdownSelect
+			value={$settings.selectedCategory}
+			onChange={(value) => settings.updateSettings({ selectedCategory: value })}
+			options={categoryOptions}
+			backgroundColor="bg-base-200"
+			specialFirstOption={true}
+		/>
+	</div>
+</div>
+{#snippet podcastGrid(items: Podcast[])}
+	<div class={sectionClasses}>
+		<VirtualList {items} estimatedItemHeight={97.5}>
 			<svelte:fragment let:item>
+				{@const podcast = item as Podcast}
+				{@const hit = searchMatch(podcast)}
 				<PodcastCard
-					podcast={item as Podcast}
-					expanded={expandedPodcasts.has((item as Podcast).id)}
+					{podcast}
+					expanded={expandedPodcasts.has(podcast.id)}
 					onExpand={handlePodcastExpand}
+					matchField={hit?.matchField}
+					matchedEpisodeIds={hit?.matchedEpisodeIds}
+					highlightQuery={isSearching ? searchQuery : ''}
 				/>
 			</svelte:fragment>
 		</VirtualList>
 	</div>
-	<div class="divider"></div>
-{/if}
+{/snippet}
 
-<h2 class={[headerClasses, headerTextClasses]}>{$t.home.radio}</h2>
-<div class={sectionClasses}>
-	{#if $radios.length === 0}
-		{#each Array(4) as _}
-			<SkeletonCard />
-		{/each}
-	{:else if otherRadios.length === 0}
-		<p class="text-base-content-secondary">{$t.home.allStationsInFavorites}</p>
-	{:else}
-		<VirtualList items={otherRadios} estimatedItemHeight={97.5}>
-			<svelte:fragment let:item>
-				<RadioCard radio={item as Radio} />
-			</svelte:fragment>
-		</VirtualList>
-	{/if}
-</div>
-
-<div class="divider"></div>
-
-<div class="flex items-start items-center justify-between {headerClasses}">
-	<h2 class={[headerTextClasses]}>{$t.home.archive}</h2>
-	<DropdownSelect
-		value={$settings.selectedCategory}
-		onChange={(value) => settings.updateSettings({ selectedCategory: value })}
-		options={categoryOptions}
-		backgroundColor="bg-base-200"
-		specialFirstOption={true}
-	/>
-</div>
-<div class={sectionClasses}>
-	{#if $podcasts.length === 0}
+{#if $podcasts.length === 0}
+	<div class={sectionClasses}>
 		{#each Array(6) as _}
 			<SkeletonCard />
 		{/each}
-	{:else if otherPodcasts.length === 0}
-		<p class="text-base-content-secondary">{$t.home.allArchiveInFavorites}</p>
+	</div>
+{:else if isSearching}
+	{#if archivePodcasts.length === 0}
+		<p class="text-base-content-secondary">{$t.home.searchNoResults}</p>
 	{:else}
-		<VirtualList items={otherPodcasts} estimatedItemHeight={97.5}>
-			<svelte:fragment let:item>
-				<PodcastCard
-					podcast={item as Podcast}
-					expanded={expandedPodcasts.has((item as Podcast).id)}
-					onExpand={handlePodcastExpand}
-				/>
-			</svelte:fragment>
-		</VirtualList>
+		{#if exactPodcasts.length > 0}
+			<h3 class="mb-2 text-lg font-semibold sm:mb-4">{$t.home.searchExactMatches}</h3>
+			{@render podcastGrid(exactPodcasts)}
+		{/if}
+		{#if similarPodcasts.length > 0}
+			{#if exactPodcasts.length > 0}
+				<div class="divider"></div>
+			{/if}
+			<h3 class="mb-2 text-lg font-semibold sm:mb-4">{$t.home.searchSimilarMatches}</h3>
+			{@render podcastGrid(similarPodcasts)}
+		{/if}
 	{/if}
-</div>
+{:else if archivePodcasts.length === 0}
+	<p class="text-base-content-secondary">{$t.home.allArchiveInFavorites}</p>
+{:else}
+	{@render podcastGrid(archivePodcasts)}
+{/if}


### PR DESCRIPTION
## Summary
- Add archive search for podcast titles and episode names
- Group results into exact and similar matches, with matched episodes highlighted in podcast cards
- Include TR/EN UI strings and a dedicated search input component

## Test plan
- [ ] Open the home page and confirm the search input appears above the podcast list
- [ ] Search for a known podcast title and verify exact matches appear first
- [ ] Search for part of an episode name and verify the matching podcast expands/shows the episode
- [ ] Clear the search and confirm the normal category/archive view returns
- [ ] Switch language to TR and EN and verify search labels, placeholders, and empty-state text


Made with [Cursor](https://cursor.com)