### PR TITLE
Fix category dropdown positioning and reset filter on new search

### DIFF
--- a/src/lib/components/utility/DropdownSelect.svelte
+++ b/src/lib/components/utility/DropdownSelect.svelte
@@ -58,22 +58,16 @@
 		}
 	}
 
-	function scrollToSelected() {
+	async function scrollToSelected() {
 		const selectedOption = options.find((opt) => opt.value === value);
 		if (selectedOption) {
 			const optionElement = dropdownContentRef?.querySelector(
 				`[data-value="${selectedOption.value}"]`
 			);
 			if (optionElement) {
-				scrollIntoViewPromise(optionElement, { behavior: 'smooth', block: 'nearest' });
+				await scrollIntoViewPromise(optionElement, { behavior: 'smooth', block: 'nearest' });
 			}
 		}
-	}
-
-	async function scrollToContent() {
-		if (!dropdownContentRef) return;
-		await scrollIntoViewPromise(dropdownContentRef, { behavior: 'smooth', block: 'nearest' });
-		scrollToSelected();
 	}
 
 	$: if (typeof window !== 'undefined' && value) {
@@ -81,51 +75,71 @@
 	}
 
 	let offsetX = 0;
-	let offsetY = 0;
 	let transform = 'translateX(-50%)';
+
+	function resetTransform() {
+		offsetX = 0;
+		transform = 'translateX(-50%)';
+	}
+
 	async function adjustPosition() {
 		if (!dropdownContentRef) return;
 
-		await new Promise((resolve) => setTimeout(resolve, 0));
+		resetTransform();
+
+		// Let layout settle before measuring
+		await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 
 		const rect = dropdownContentRef.getBoundingClientRect();
-		const viewportWidth = window.innerWidth;
-		const viewportHeight = window.innerHeight;
-
 		const margin = 8;
+		const viewportWidth = window.innerWidth;
 
+		// Keep opening in the configured direction; only nudge horizontally if clipped
 		if (rect.right > viewportWidth - margin) {
-			offsetX += viewportWidth - rect.right - margin;
+			offsetX = viewportWidth - rect.right - margin;
 		} else if (rect.left < margin) {
-			offsetX += margin - rect.left;
+			offsetX = margin - rect.left;
 		}
 
-		if (rect.bottom > viewportHeight) {
-			offsetY += viewportHeight - rect.bottom;
-		} else if (rect.top < 0) {
-			offsetY -= rect.top;
-		}
-
-		if (offsetX !== 0 || offsetY !== 0) {
-			transform = `translateX(-50%) translate(${offsetX}px, ${offsetY}px)`;
-		}
+		transform =
+			offsetX !== 0 ? `translateX(-50%) translateX(${offsetX}px)` : 'translateX(-50%)';
 	}
+
+	async function handleFocusIn(event: FocusEvent) {
+		const root = event.currentTarget as HTMLElement;
+		const prev = event.relatedTarget;
+		if (prev instanceof Node && root.contains(prev)) return;
+
+		await scrollToSelected();
+		await adjustPosition();
+	}
+
+	function handleFocusOut(event: FocusEvent) {
+		const root = event.currentTarget as HTMLElement;
+		const next = event.relatedTarget;
+		if (next instanceof Node && root.contains(next)) return;
+		resetTransform();
+	}
+
 	onMount(() => {
 		if (typeof window === 'undefined' || !dropdownRef) return;
 
-		const handler = () => adjustPosition();
-		dropdownRef.addEventListener('animationend', handler);
+		const handler = () => {
+			void adjustPosition();
+		};
 		window.addEventListener('resize', handler);
-		handler();
 
 		return () => {
-			dropdownRef?.removeEventListener('animationend', handler);
 			window.removeEventListener('resize', handler);
 		};
 	});
 </script>
 
-<div class="dropdown {dropDirection === 'top' ? 'dropdown-top' : ''}">
+<div
+	class="dropdown {dropDirection === 'top' ? 'dropdown-top' : 'dropdown-bottom'}"
+	on:focusin={handleFocusIn}
+	on:focusout={handleFocusOut}
+>
 	<button
 		tabindex="-1"
 		aria-hidden="true"
@@ -142,10 +156,6 @@
 		class="h-full w-full"
 		aria-label={`Select ${options.find((opt) => opt.value === value)?.label}`}
 		on:keydown={handleKeydown}
-		on:focusin={() => {
-			scrollToContent();
-			adjustPosition();
-		}}
 	>
 		{#if $$slots.trigger}
 			<slot name="trigger" />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -69,8 +69,17 @@
 	$: archivePodcasts = isSearching ? searchHits.map((hit) => hit.podcast) : otherPodcasts;
 
 	$: if ($searchQuery !== lastSearchKey) {
+		const previousQuery = lastSearchKey;
 		lastSearchKey = $searchQuery;
 		expandedPodcasts = new Set();
+
+		// New/changed search should cover all categories; keep category only for the
+		// current query (user may narrow results after searching).
+		const next = $searchQuery.trim();
+		const prev = previousQuery.trim();
+		if (next && next !== prev && selectedCategory !== ALL_CATEGORY) {
+			settings.updateSettings({ selectedCategory: ALL_CATEGORY });
+		}
 	}
 
 	$: if (typeof window !== 'undefined' && $searchQuery.trim()) {


### PR DESCRIPTION
## Summary
- Keep the category dropdown opening downward with stable positioning (no accumulated vertical offset / upward drift).
- Reset the selected category to All when the search query changes, so a new search covers all categories while still allowing narrowing within the current query.

## Test plan
- [ ] Open the category dropdown from various scroll positions; it should always open downward and stay aligned under the trigger.
- [ ] Search, then pick a category — results stay limited to that category.
- [ ] Change the search query — category resets to All and results search across all categories again.
- [ ] Player dropdowns that use `dropDirection="top"` still open upward.


Made with [Cursor](https://cursor.com)