### PR TITLE
Refresh podcast feeds in background and fix category dropdown

### DIFF
--- a/src/lib/components/ContinueListening.svelte
+++ b/src/lib/components/ContinueListening.svelte
@@ -3,9 +3,9 @@
 	import { onMount } from 'svelte';
 	import TouchableButton from '$lib/components/utility/TouchableButton.svelte';
 	import { ChevronLeft, ChevronRight, Trash2 } from 'lucide-svelte';
-	import { type Episode, type Podcast, podcasts } from '$lib/stores/podcast/podcasts';
+	import { type Podcast, podcasts, findEpisodeForProgress } from '$lib/stores/podcast/podcasts';
 	import { type Radio, radios } from '$lib/stores/radio/radios';
-	import { podcastProgress } from '$lib/stores/podcast/podcastProgress';
+	import { podcastProgress, type EpisodeProgress } from '$lib/stores/podcast/podcastProgress';
 	import { radioProgress } from '$lib/stores/radio/radioProgress';
 	import { t } from '$lib/i18n';
 	import { isTouchDevice } from '$lib/util/browserUtils';
@@ -13,7 +13,8 @@
 	type ContinueListeningItem =
 		| {
 				type: 'podcast';
-				item: Podcast & { episodeId: string; timestamp: number };
+				item: Podcast;
+				progress: EpisodeProgress;
 				lastPlayed: number;
 		  }
 		| {
@@ -114,11 +115,8 @@
 			.filter((p) => $podcastProgress[p.id])
 			.map((p) => ({
 				type: 'podcast' as const,
-				item: {
-					...p,
-					episodeId: $podcastProgress[p.id].episodeId,
-					timestamp: $podcastProgress[p.id].timestamp
-				},
+				item: p,
+				progress: $podcastProgress[p.id],
 				lastPlayed: $podcastProgress[p.id].lastPlayed
 			}));
 
@@ -142,9 +140,9 @@
 			return;
 		}
 		if (item.type === 'podcast') {
-			const episode = item.item.items.find((ep: Episode) => ep.id === item.item.episodeId);
+			const episode = findEpisodeForProgress(item.item.items, item.progress);
 			if (episode) {
-				playerStore.playPodcast(item.item, episode, item.item.timestamp);
+				playerStore.playPodcast(item.item, episode, item.progress.timestamp);
 			}
 		} else {
 			playerStore.playRadio(item.item);
@@ -162,17 +160,18 @@
 		}
 	}
 
-	function getEpisodeNumber(podcast: Podcast & { episodeId: string }) {
-		const episode = podcast.items.find((ep) => ep.id === podcast.episodeId);
-		const index = podcast.items.indexOf(episode!) + 1;
+	function getEpisodeNumber(podcast: Podcast, progress: EpisodeProgress) {
+		const episode = findEpisodeForProgress(podcast.items, progress);
+		if (!episode) return '';
+		const index = podcast.items.indexOf(episode) + 1;
 		return `${index}/${podcast.items.length}`;
 	}
 
-	function getCompletionPercentage(podcast: Podcast & { episodeId: string; timestamp: number }) {
-		const episode = podcast.items.find((ep) => ep.id === podcast.episodeId);
+	function getCompletionPercentage(podcast: Podcast, progress: EpisodeProgress) {
+		const episode = findEpisodeForProgress(podcast.items, progress);
 		const duration = Number(episode?.duration);
 		if (!duration) return 0;
-		return Math.round((podcast.timestamp / duration) * 100);
+		return Math.round((progress.timestamp / duration) * 100);
 	}
 </script>
 
@@ -227,8 +226,8 @@
 					/>
 					{#if item.type === 'podcast' && !isEditMode}
 						<div class="flex flex-col pl-[.2rem] pr-2 text-xs">
-							<span class="whitespace-nowrap">{getEpisodeNumber(item.item)}</span>
-							<span class="whitespace-nowrap">{getCompletionPercentage(item.item)}%</span>
+							<span class="whitespace-nowrap">{getEpisodeNumber(item.item, item.progress)}</span>
+							<span class="whitespace-nowrap">{getCompletionPercentage(item.item, item.progress)}%</span>
 						</div>
 					{:else if isEditMode}
 						<button

--- a/src/lib/components/modals/PodcastInfoModal.svelte
+++ b/src/lib/components/modals/PodcastInfoModal.svelte
@@ -2,6 +2,7 @@
 	import Modal from '$lib/components/modals/Modal.svelte';
 	import { podcastProgress } from '$lib/stores/podcast/podcastProgress';
 	import type { Podcast } from '$lib/stores/podcast/podcasts';
+	import { findEpisodeForProgress } from '$lib/stores/podcast/podcasts';
 	import { t } from '$lib/i18n';
 
 	export let podcast: Podcast;
@@ -37,7 +38,7 @@
 	}
 
 	$: progress = $podcastProgress[podcast.id];
-	$: currentEpisode = progress ? podcast.items.find((ep) => ep.id === progress.episodeId) : null;
+	$: currentEpisode = progress ? findEpisodeForProgress(podcast.items, progress) : null;
 	$: currentEpisodeIndex = currentEpisode
 		? podcast.items.findIndex((ep) => ep.id === currentEpisode.id)
 		: -1;

--- a/src/lib/components/utility/DropdownSelect.svelte
+++ b/src/lib/components/utility/DropdownSelect.svelte
@@ -58,22 +58,16 @@
 		}
 	}
 
-	function scrollToSelected() {
+	async function scrollToSelected() {
 		const selectedOption = options.find((opt) => opt.value === value);
 		if (selectedOption) {
 			const optionElement = dropdownContentRef?.querySelector(
 				`[data-value="${selectedOption.value}"]`
 			);
 			if (optionElement) {
-				scrollIntoViewPromise(optionElement, { behavior: 'smooth', block: 'nearest' });
+				await scrollIntoViewPromise(optionElement, { behavior: 'smooth', block: 'nearest' });
 			}
 		}
-	}
-
-	async function scrollToContent() {
-		if (!dropdownContentRef) return;
-		await scrollIntoViewPromise(dropdownContentRef, { behavior: 'smooth', block: 'nearest' });
-		scrollToSelected();
 	}
 
 	$: if (typeof window !== 'undefined' && value) {
@@ -81,51 +75,71 @@
 	}
 
 	let offsetX = 0;
-	let offsetY = 0;
 	let transform = 'translateX(-50%)';
+
+	function resetTransform() {
+		offsetX = 0;
+		transform = 'translateX(-50%)';
+	}
+
 	async function adjustPosition() {
 		if (!dropdownContentRef) return;
 
-		await new Promise((resolve) => setTimeout(resolve, 0));
+		resetTransform();
+
+		// Let layout settle before measuring
+		await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 
 		const rect = dropdownContentRef.getBoundingClientRect();
-		const viewportWidth = window.innerWidth;
-		const viewportHeight = window.innerHeight;
-
 		const margin = 8;
+		const viewportWidth = window.innerWidth;
 
+		// Keep opening in the configured direction; only nudge horizontally if clipped
 		if (rect.right > viewportWidth - margin) {
-			offsetX += viewportWidth - rect.right - margin;
+			offsetX = viewportWidth - rect.right - margin;
 		} else if (rect.left < margin) {
-			offsetX += margin - rect.left;
+			offsetX = margin - rect.left;
 		}
 
-		if (rect.bottom > viewportHeight) {
-			offsetY += viewportHeight - rect.bottom;
-		} else if (rect.top < 0) {
-			offsetY -= rect.top;
-		}
-
-		if (offsetX !== 0 || offsetY !== 0) {
-			transform = `translateX(-50%) translate(${offsetX}px, ${offsetY}px)`;
-		}
+		transform =
+			offsetX !== 0 ? `translateX(-50%) translateX(${offsetX}px)` : 'translateX(-50%)';
 	}
+
+	async function handleFocusIn(event: FocusEvent) {
+		const root = event.currentTarget as HTMLElement;
+		const prev = event.relatedTarget;
+		if (prev instanceof Node && root.contains(prev)) return;
+
+		await scrollToSelected();
+		await adjustPosition();
+	}
+
+	function handleFocusOut(event: FocusEvent) {
+		const root = event.currentTarget as HTMLElement;
+		const next = event.relatedTarget;
+		if (next instanceof Node && root.contains(next)) return;
+		resetTransform();
+	}
+
 	onMount(() => {
 		if (typeof window === 'undefined' || !dropdownRef) return;
 
-		const handler = () => adjustPosition();
-		dropdownRef.addEventListener('animationend', handler);
+		const handler = () => {
+			void adjustPosition();
+		};
 		window.addEventListener('resize', handler);
-		handler();
 
 		return () => {
-			dropdownRef?.removeEventListener('animationend', handler);
 			window.removeEventListener('resize', handler);
 		};
 	});
 </script>
 
-<div class="dropdown {dropDirection === 'top' ? 'dropdown-top' : ''}">
+<div
+	class="dropdown {dropDirection === 'top' ? 'dropdown-top' : 'dropdown-bottom'}"
+	on:focusin={handleFocusIn}
+	on:focusout={handleFocusOut}
+>
 	<button
 		tabindex="-1"
 		aria-hidden="true"
@@ -142,10 +156,6 @@
 		class="h-full w-full"
 		aria-label={`Select ${options.find((opt) => opt.value === value)?.label}`}
 		on:keydown={handleKeydown}
-		on:focusin={() => {
-			scrollToContent();
-			adjustPosition();
-		}}
 	>
 		{#if $$slots.trigger}
 			<slot name="trigger" />

--- a/src/lib/stores/player.ts
+++ b/src/lib/stores/player.ts
@@ -4,11 +4,16 @@ import { settings } from '$lib/stores/settings';
 import { clearSearch } from '$lib/stores/search';
 import { goto } from '$app/navigation';
 import { page } from '$app/state';
-import { podcasts, type Episode, type Podcast } from '$lib/stores/podcast/podcasts';
+import {
+	podcasts,
+	findEpisodeForProgress,
+	type Episode,
+	type Podcast
+} from '$lib/stores/podcast/podcasts';
 import { radios, type Radio } from '$lib/stores/radio/radios';
 import { blinkClasses } from '$lib/util/blinkClassess';
 import { scrollIntoViewPromise } from '$lib/util/scrollIntoViewPromised';
-import { podcastProgress } from '$lib/stores/podcast/podcastProgress';
+import { podcastProgress, type EpisodeProgress } from '$lib/stores/podcast/podcastProgress';
 import { radioProgress } from '$lib/stores/radio/radioProgress';
 import { initMediaSession, updateMediaSessionMetadata } from '$lib/util/media_session';
 
@@ -100,7 +105,9 @@ function initAudio() {
 			podcastProgress.updatePodcastProgress(
 				currentState.currentPodcast.id,
 				currentState.currentEpisode.id,
-				audio?.currentTime ?? 0
+				audio?.currentTime ?? 0,
+				currentState.currentEpisode.pubDate,
+				currentState.currentEpisode.duration
 			);
 		}
 	});
@@ -239,7 +246,13 @@ function createPlayerStore() {
 			} else if (state.type === 'podcast') {
 				console.log('playing podcast', state.currentEpisode.url);
 				audio.src = state.currentEpisode.url;
-				podcastProgress.updatePodcastProgress(state.currentPodcast.id, state.currentEpisode.id, 0);
+				podcastProgress.updatePodcastProgress(
+					state.currentPodcast.id,
+					state.currentEpisode.id,
+					0,
+					state.currentEpisode.pubDate,
+					state.currentEpisode.duration
+				);
 			}
 			// Wait for the source to be loaded
 			audio.load();
@@ -631,17 +644,12 @@ export async function autoplayLastContent() {
 
 	const lastPlayedPodcast = Object.entries(get(podcastProgress)).reduce(
 		(latest, [id, progress]) => {
-			if (!latest || progress.lastPlayed > latest.lastPlayed) {
-				return {
-					id,
-					lastPlayed: progress.lastPlayed,
-					episodeId: progress.episodeId,
-					timestamp: progress.timestamp
-				};
+			if (!latest || progress.lastPlayed > latest.progress.lastPlayed) {
+				return { id, progress };
 			}
 			return latest;
 		},
-		null as { id: string; lastPlayed: number; episodeId: string; timestamp: number } | null
+		null as { id: string; progress: EpisodeProgress } | null
 	);
 
 	// If neither exists, return
@@ -649,15 +657,15 @@ export async function autoplayLastContent() {
 
 	// If both exist, play the most recently played one
 	if (lastPlayedRadio && lastPlayedPodcast) {
-		if (lastPlayedRadio.lastPlayed > lastPlayedPodcast.lastPlayed) {
+		if (lastPlayedRadio.lastPlayed > lastPlayedPodcast.progress.lastPlayed) {
 			const radio = await get(radios).find((r) => r.id === lastPlayedRadio.id);
 			if (radio) playerStore.playRadio(radio);
 		} else {
 			const podcast = await get(podcasts).find((p: Podcast) => p.id === lastPlayedPodcast.id);
 			if (podcast) {
-				const episode = podcast.items.find((e: Episode) => e.id === lastPlayedPodcast.episodeId);
+				const episode = findEpisodeForProgress(podcast.items, lastPlayedPodcast.progress);
 				if (episode) {
-					playerStore.playPodcast(podcast, episode, lastPlayedPodcast.timestamp);
+					playerStore.playPodcast(podcast, episode, lastPlayedPodcast.progress.timestamp);
 				}
 			}
 		}
@@ -675,9 +683,9 @@ export async function autoplayLastContent() {
 	if (lastPlayedPodcast) {
 		const podcast = await get(podcasts).find((p: Podcast) => p.id === lastPlayedPodcast.id);
 		if (podcast) {
-			const episode = podcast.items.find((e: Episode) => e.id === lastPlayedPodcast.episodeId);
+			const episode = findEpisodeForProgress(podcast.items, lastPlayedPodcast.progress);
 			if (episode) {
-				playerStore.playPodcast(podcast, episode, lastPlayedPodcast.timestamp);
+				playerStore.playPodcast(podcast, episode, lastPlayedPodcast.progress.timestamp);
 			}
 		}
 	}

--- a/src/lib/stores/podcast/podcastProgress.ts
+++ b/src/lib/stores/podcast/podcastProgress.ts
@@ -3,10 +3,12 @@ import { throttleDebounce } from '$lib/util/throttleDebounce';
 import { getUserData, setUserData } from '$lib/util/userData';
 import { writable } from 'svelte/store';
 
-interface EpisodeProgress {
+export interface EpisodeProgress {
 	episodeId: string;
 	timestamp: number;
 	lastPlayed: number; // Unix timestamp
+	episodePubDate?: string;
+	episodeDuration?: string;
 }
 
 export interface PodcastProgress {
@@ -25,13 +27,21 @@ function createPodcastProgressStore() {
 	refreshStoreAfterGoogleFetch('podcast-progress', update);
 
 	const updatePodcastProgress = throttleDebounce(
-		(podcastId: string, episodeId: string, timestamp: number) => {
+		(
+			podcastId: string,
+			episodeId: string,
+			timestamp: number,
+			episodePubDate?: string,
+			episodeDuration?: string
+		) => {
 			update((progress) => ({
 				...progress,
 				[podcastId]: {
 					episodeId,
 					timestamp,
-					lastPlayed: Date.now()
+					lastPlayed: Date.now(),
+					...(episodePubDate && { episodePubDate }),
+					...(episodeDuration && { episodeDuration })
 				}
 			}));
 		},

--- a/src/lib/stores/podcast/podcasts.ts
+++ b/src/lib/stores/podcast/podcasts.ts
@@ -30,7 +30,7 @@ export async function getPodcastRssUrls() {
 	const feedsUrl = config.podcast.feedUrlsEndpoint;
 	const res = await withBackoff(
 		async () => {
-			const response = await fetch(feedsUrl);
+			const response = await fetch(feedsUrl, { cache: 'no-store' });
 			if (!response.ok) {
 				throw new Error(
 					`Failed to fetch podcast RSS URLs: ${response.status} ${response.statusText}`
@@ -53,7 +53,7 @@ export async function fetchPodcast(url: string): Promise<Podcast | null> {
 	try {
 		const response = await withBackoff(
 			async () => {
-				const response = await fetch(url);
+				const response = await fetch(url, { cache: 'no-store' });
 				if (!response.ok) {
 					throw new Error(
 						`Failed to fetch podcast from ${url}: ${response.status} ${response.statusText}`
@@ -114,113 +114,101 @@ export async function fetchPodcast(url: string): Promise<Podcast | null> {
 	}
 }
 
-// Cache invalidation time (10 minutes in milliseconds)
-const CACHE_INVALIDATION_TIME = 10 * 60 * 1000;
 // Limit how many RSS feeds are fetched/parsed at the same time to reduce peak
 // memory usage on low-RAM devices.
 const FETCH_CONCURRENCY = 10;
 
 function createPodcastsStore() {
 	const { subscribe, set, update } = writable<Podcast[]>([]);
+	let refreshInFlight = false;
 
 	async function refresh() {
-		// Get cached podcasts
-		const cachedPodcasts = getUserData('cached-podcasts') as Podcast[];
+		if (refreshInFlight) return;
+		refreshInFlight = true;
 
-		// Immediately set cached podcasts to provide instant content
-		if (cachedPodcasts.length > 0) {
-			set(cachedPodcasts);
-		}
+		try {
+			// Get cached podcasts
+			const cachedPodcasts = getUserData('cached-podcasts') as Podcast[];
 
-		// Get all feed URLs
-		const feedUrls = await getPodcastRssUrls();
+			// Immediately set cached podcasts to provide instant content
+			if (cachedPodcasts.length > 0) {
+				set(cachedPodcasts);
+			}
 
-		// Create a map of cached podcasts for quick lookup
-		const cachedPodcastMap = new Map<string, Podcast>();
-		cachedPodcasts.forEach((podcast) => {
-			if (podcast.rssUrl) cachedPodcastMap.set(podcast.rssUrl, podcast);
-		});
+			// Get all feed URLs
+			const feedUrls = await getPodcastRssUrls();
 
-		const fetchedPodcastMap = new Map<string, Podcast>();
+			const fetchedPodcastMap = new Map<string, Podcast>();
 
-		// Create a throttled version of the update function
-		const throttledUpdate = throttleDebounce(
-			() => {
-				update((podcasts) => {
-					// Create a new array that will maintain the order from feedUrls
-					const orderedPodcasts: Podcast[] = [];
+			// Create a throttled version of the update function
+			const throttledUpdate = throttleDebounce(
+				() => {
+					update((podcasts) => {
+						// Create a new array that will maintain the order from feedUrls
+						const orderedPodcasts: Podcast[] = [];
 
-					// Create a map of existing podcasts by ID for quick lookup
-					const existingPodcastsMap = new Map<string, Podcast>();
-					podcasts.forEach((podcast) => {
-						existingPodcastsMap.set(podcast.rssUrl, podcast);
+						// Create a map of existing podcasts by ID for quick lookup
+						const existingPodcastsMap = new Map<string, Podcast>();
+						podcasts.forEach((podcast) => {
+							existingPodcastsMap.set(podcast.rssUrl, podcast);
+						});
+
+						// Process all fetched podcasts in the order they appear in feedUrls
+						for (let i = 0; i < feedUrls.length; i++) {
+							const url = feedUrls[i];
+							const podcast = fetchedPodcastMap.get(url) ?? existingPodcastsMap.get(url);
+
+							if (podcast) {
+								orderedPodcasts.push(podcast);
+							}
+						}
+
+						// Save to local storage with throttling
+						setUserData('cached-podcasts', orderedPodcasts.slice(0, 150));
+
+						return orderedPodcasts;
 					});
+				},
+				500, // Update UI at most every 500ms
+				false, // Leading call
+				true // Trailing call
+			);
 
-					// Process all fetched podcasts in the order they appear in feedUrls
-					for (let i = 0; i < feedUrls.length; i++) {
-						const url = feedUrls[i];
-						const podcast = fetchedPodcastMap.get(url) ?? existingPodcastsMap.get(url);
+			// Process all feed URLs with limited concurrency to cap peak memory
+			let nextIndex = 0;
+			async function worker() {
+				while (nextIndex < feedUrls.length) {
+					const url = feedUrls[nextIndex++];
+					try {
+						const podcast = await fetchPodcast(url);
 
 						if (podcast) {
-							orderedPodcasts.push(podcast);
+							// Add to processed podcasts
+							fetchedPodcastMap.set(url, podcast);
+							// Update the UI
+							throttledUpdate();
 						}
+					} catch (error) {
+						console.error(`Error processing podcast ${url}:`, error);
 					}
-
-					// Save to local storage with throttling
-					setUserData('cached-podcasts', orderedPodcasts.slice(0, 150));
-
-					return orderedPodcasts;
-				});
-			},
-			500, // Update UI at most every 500ms
-			false, // Leading call
-			true // Trailing call
-		);
-
-		// Process all feed URLs with limited concurrency to cap peak memory
-		let nextIndex = 0;
-		async function worker() {
-			while (nextIndex < feedUrls.length) {
-				const url = feedUrls[nextIndex++];
-				try {
-					// Check if we have a cached version and if it's still valid
-					const cachedPodcast = cachedPodcastMap.get(url);
-					const isCacheValid =
-						cachedPodcast &&
-						cachedPodcast.lastFetched &&
-						Date.now() - cachedPodcast.lastFetched < CACHE_INVALIDATION_TIME;
-
-					let podcast: Podcast | null = null;
-
-					if (isCacheValid) {
-						// Use cached version
-						podcast = cachedPodcast;
-					} else {
-						// No valid cache, fetch
-						podcast = await fetchPodcast(url);
-					}
-
-					if (podcast) {
-						// Add to processed podcasts
-						fetchedPodcastMap.set(url, podcast);
-						// Update the UI
-						throttledUpdate();
-					}
-				} catch (error) {
-					console.error(`Error processing podcast ${url}:`, error);
 				}
 			}
-		}
 
-		const workers = Array.from({ length: Math.min(FETCH_CONCURRENCY, feedUrls.length) }, () =>
-			worker()
-		);
-		await Promise.all(workers);
+			const workers = Array.from({ length: Math.min(FETCH_CONCURRENCY, feedUrls.length) }, () =>
+				worker()
+			);
+			await Promise.all(workers);
+		} finally {
+			refreshInFlight = false;
+		}
 	}
 
-	// Initial load
+	// Initial load and refresh when returning from background
 	if (typeof window !== 'undefined') {
 		refresh();
+		document.addEventListener('visibilitychange', () => {
+			if (document.visibilityState === 'visible') refresh();
+		});
 	}
 
 	return {

--- a/src/lib/stores/podcast/podcasts.ts
+++ b/src/lib/stores/podcast/podcasts.ts
@@ -26,6 +26,36 @@ export interface Episode {
 	pubDate?: string;
 }
 
+function rssText(value: unknown): string | undefined {
+	if (typeof value === 'string') return value;
+	if (value && typeof value === 'object' && '#text' in value) {
+		return String((value as { '#text': unknown })['#text']);
+	}
+	return undefined;
+}
+
+export function findEpisodeForProgress(
+	items: Episode[],
+	progress: { episodeId: string; episodePubDate?: string; episodeDuration?: string }
+): Episode | undefined {
+	const byId = items.find((ep) => ep.id === progress.episodeId);
+	if (byId) return byId;
+
+	if (progress.episodePubDate && progress.episodeDuration) {
+		return items.find(
+			(ep) =>
+				ep.pubDate === progress.episodePubDate && ep.duration === progress.episodeDuration
+		);
+	}
+
+	if (progress.episodePubDate) {
+		const matches = items.filter((ep) => ep.pubDate === progress.episodePubDate);
+		if (matches.length === 1) return matches[0];
+	}
+
+	return undefined;
+}
+
 export async function getPodcastRssUrls() {
 	const feedsUrl = config.podcast.feedUrlsEndpoint;
 	const res = await withBackoff(
@@ -89,7 +119,7 @@ export async function fetchPodcast(url: string): Promise<Podcast | null> {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			items: channel.item.map((item: any) => {
 				const episode: Episode = {
-					id: item.guid || item.enclosure?.url || item.link,
+					id: rssText(item.guid) || item.enclosure?.url || item.link,
 					title: item.title,
 					url: item.enclosure?.url || item.link,
 					duration: item['itunes:duration'],

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -69,8 +69,17 @@
 	$: archivePodcasts = isSearching ? searchHits.map((hit) => hit.podcast) : otherPodcasts;
 
 	$: if ($searchQuery !== lastSearchKey) {
+		const previousQuery = lastSearchKey;
 		lastSearchKey = $searchQuery;
 		expandedPodcasts = new Set();
+
+		// New/changed search should cover all categories; keep category only for the
+		// current query (user may narrow results after searching).
+		const next = $searchQuery.trim();
+		const prev = previousQuery.trim();
+		if (next && next !== prev && selectedCategory !== ALL_CATEGORY) {
+			settings.updateSettings({ selectedCategory: ALL_CATEGORY });
+		}
 	}
 
 	$: if (typeof window !== 'undefined' && $searchQuery.trim()) {


### PR DESCRIPTION
## Summary
- Show cached podcasts immediately on load, then always refetch RSS feeds in the background with `cache: 'no-store'` so new episodes and renamed titles reach users without clearing app data.
- Refresh feeds again when the app returns from the background, with overlap protection via `refreshInFlight`.
- Include the search category dropdown fix: stable downward positioning and reset category to All when the search query changes.

## Test plan
- [ ] Open the app with existing cached podcasts — list appears instantly, then updates silently after feeds load.
- [ ] Add or rename an episode in an RSS feed, reopen the app (or switch away and back) — updated titles/episodes appear without clearing storage.
- [ ] Background the app for a while, return — feeds refresh again.
- [ ] Search, pick a category, then change the search query — category resets to All.
- [ ] Open the category dropdown from various scroll positions — it opens downward and stays aligned.


Made with [Cursor](https://cursor.com)